### PR TITLE
Bounding Boxes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -62,6 +62,7 @@
       }
     }, {
       "enforceForRenamedProperties": false
-    }]
+    }],
+    "lines-between-class-members": ["error", "always", { exceptAfterSingleLine: true }]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -50,6 +50,18 @@
     "jsdoc/require-returns-check": 1,
     "jsdoc/require-returns-description": 0,
     "jsdoc/require-returns-type": 1,
-    "jsdoc/valid-types": 1
+    "jsdoc/valid-types": 1,
+    "prefer-destructuring": ["error", {
+      "VariableDeclarator": {
+        "array": true,
+        "object": true
+      },
+      "AssignmentExpression": {
+        "array": false,
+        "object": false
+      }
+    }, {
+      "enforceForRenamedProperties": false
+    }]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3913,6 +3913,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hex-rgb": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.1.0.tgz",
+      "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "webpack": "^4.39.1",
     "webpack-cli": "^3.3.6"
   },
-  "author": "Grant Blakeman <gblakeman@linkedin.com>"
+  "author": "Grant Blakeman <gblakeman@linkedin.com>",
+  "dependencies": {
+    "hex-rgb": "^4.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "webpack": "^4.39.1",
     "webpack-cli": "^3.3.6"
   },
-  "author": "Grant Blakeman <gblakeman@linkedin.com>",
   "dependencies": {
     "hex-rgb": "^4.1.0"
-  }
+  },
+  "author": "Grant Blakeman <gblakeman@linkedin.com>"
 }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "lint:staged": "lint-staged"
   },
   "lint-staged": {
-    "*.js": "eslint",
-    "*.css": "stylelint"
+    "*.{js,jsx,tsx,ts}": "eslint",
+    "*.{css,scss}": "stylelint"
   },
   "pre-commit": "lint:staged",
   "devDependencies": {

--- a/src/Crawler.ts
+++ b/src/Crawler.ts
@@ -1,4 +1,4 @@
-import { FRAME_TYPES } from './constants';
+// import { FRAME_TYPES } from './constants';
 
 /** WIP
  * @description A class to handle traversing an array of selected items and return useful items

--- a/src/Crawler.ts
+++ b/src/Crawler.ts
@@ -1,0 +1,135 @@
+import { FRAME_TYPES } from './constants';
+
+/** WIP
+ * @description A class to handle traversing an array of selected items and return useful items
+ * (parent layer, frame, page, etc). It will also find items based on ID (or timestamp).
+ *
+ * @class
+ * @name Crawler
+ *
+ * @constructor
+ *
+ * @property selectionArray The array of selected items.
+ */
+export default class Crawler {
+  array: Array<any>;
+  constructor({ for: selectionArray }) {
+    this.array = selectionArray;
+  }
+
+  /**
+   * @description Returns the first item in the array.
+   *
+   * @kind function
+   * @name first
+   * @returns {Object} The first layer item in the array.
+   */
+  first() {
+    return this.array[0];
+  }
+
+  /** WIP
+   * @description Uses `setArray` to ensure the selection array is a javascript array. Also
+   * looks into the selection for any groups and pulls out individual layers.
+   *
+   * @kind function
+   * @name all
+   * @returns {Object} All items in the array as a javascript array.
+   */
+  all() {
+    return this.array;
+    // const initialSelection = setArray(this.array);
+    // const flatSelection = [];
+    // initialSelection.forEach((layer) => {
+    //   if (
+    //     fromNative(layer).type === 'Group'
+    //     || fromNative(layer).type === 'Artboard'
+    //   ) {
+    //     const innerLayers = layer.children();
+    //     innerLayers.forEach((innerLayer) => {
+    //       // .children() includes the outer layer group, so we want to exclude it
+    //       // from our flattened selection
+    //       if (
+    //         fromNative(innerLayer).type !== 'Group'
+    //         && fromNative(innerLayer).type !== 'Artboard'
+    //       ) {
+    //         flatSelection.push(innerLayer);
+    //       }
+    //     });
+    //   } else {
+    //     flatSelection.push(layer);
+    //   }
+    // });
+    // return flatSelection;
+  }
+
+  /** WIP
+   * @description Simulates Sketch’s position() object, but for an entire selection,
+   * and keeps the coordinates relative to the frame, ignoring if some of the items
+   * are grouped inside other layers.
+   *
+   * @kind function
+   * @name position
+   * @returns {Object} The `x`, `y` coordinates and `width` and `height` of an entire selection.
+   */
+  position() {
+    const thePosition = {
+      x: null,
+      y: null,
+      width: 0,
+      height: 0,
+    };
+
+    // set some intitial outer values to compare to
+    let outerX = 0;
+    let outerY = 0;
+
+    // iterate through the selected layers and update the frame inner `x`/`y` values and
+    // the outer `x`/`y` values
+    this.all().forEach((layer) => {
+      // const layerCoordinates = getPositionOnArtboard(layer);
+      const layerX = layer.x;
+      const layerY = layer.y;
+      const layerW = layer.width;
+      const layerH = layer.height;
+      const layerOuterX = layerX + layerW;
+      const layerOuterY = layerY + layerH;
+
+      // set upper-left x
+      if (
+        (!thePosition.x)
+        || (thePosition.x > layerX)
+      ) {
+        thePosition.x = layerX;
+      }
+
+      // set outerX
+      if (layerOuterX > outerX) {
+        outerX = layerOuterX;
+      }
+
+      // set upper-left y
+      if (
+        (!thePosition.y)
+        || (thePosition.y > layerY)
+      ) {
+        thePosition.y = layerY;
+      }
+
+      // set outerY
+      if (layerOuterY > outerY) {
+        outerY = layerOuterY;
+      }
+    });
+
+    // calculate the full `width`/`height` based on the inner and outer `x`/`y` values
+    const width = outerX - thePosition.x;
+    const height = outerY - thePosition.y;
+
+    // set the new `width`/`height` values
+    thePosition.width = width;
+    thePosition.height = height;
+
+    return thePosition;
+  }
+}

--- a/src/Messenger.ts
+++ b/src/Messenger.ts
@@ -1,0 +1,91 @@
+import { PLUGIN_NAME } from './constants';
+
+/**
+ * @description A class to handle UI alerts, messages, and logging.
+ *
+ * @class
+ * @name Messenger
+ *
+ * @constructor
+ *
+ * @property event The encompassing event we are logging or applying a message/alert to.
+ * @property page The Sketch file that will display messages/alerts
+ * or that the log will reference.
+ */
+export default class Messenger {
+  event: any;
+  page: any;
+
+  constructor({
+    for: event,
+    in: page,
+  }) {
+    this.event = event;
+    this.page = page;
+  }
+
+  /**
+   * @description Takes a string message and logs it at one of 2 levels (normal or error).
+   *
+   * @kind function
+   * @name log
+   * @param {string} message The string containing the message to be logged.
+   * @param {string} type The optional string declaring the type of log: error or normal (default).
+   */
+  log(message: string, type: 'normal' | 'error' = 'normal') {
+    const logType = type === 'error' ? '🆘' : '🐞';
+    const pageIdString = this.page ? ` ${this.page.id} :` : '';
+    const eventTypeString = this.event && this.event.action ? ` ${this.event.action} :` : ' Invoked :';
+
+    console.log(`${PLUGIN_NAME} ${logType}${pageIdString}${eventTypeString} ${message}`); // eslint-disable-line no-console
+  }
+
+  /**
+   * @description Takes a string message and renders it as a Toast in the Sketch UI.
+   *
+   * @kind function
+   * @name toast
+   * @param {string} message The message to be displayed in the Toast.
+   */
+  toast(message: string) {
+    if (this.page) {
+      figma.notify(message);
+    } else {
+      this.log(`Could not display: “${message}”`, 'error');
+    }
+  }
+
+  /**
+   * @description Handle the result messenging/logging.
+   *
+   * @kind function
+   * @name handleResult
+   * @param {Object} result The success/error result and accompanying log/toast message(s).
+   */
+  handleResult(
+    result: {
+      messages: {
+        toast: string,
+        log: string,
+      },
+      status: 'error' | 'success',
+    },
+  ) {
+    if (result.messages) {
+      // set up toast and log messages
+      const toastMessage = result.messages.toast;
+      const logMessage = result.messages.log;
+      const isError = (result.status === 'error');
+
+      // log a message or error
+      if (logMessage) {
+        this.log(logMessage, isError ? 'error' : null);
+      }
+
+      // toast a message or error
+      if (toastMessage) {
+        this.toast(toastMessage);
+      }
+    }
+  }
+}

--- a/src/Messenger.ts
+++ b/src/Messenger.ts
@@ -9,7 +9,7 @@ import { PLUGIN_NAME } from './constants';
  * @constructor
  *
  * @property event The encompassing event we are logging or applying a message/alert to.
- * @property page The Sketch file that will display messages/alerts
+ * @property page The Figma file that will display messages/alerts
  * or that the log will reference.
  */
 export default class Messenger {
@@ -33,15 +33,17 @@ export default class Messenger {
    * @param {string} type The optional string declaring the type of log: error or normal (default).
    */
   log(message: string, type: 'normal' | 'error' = 'normal') {
-    const logType = type === 'error' ? '🆘' : '🐞';
+    const logType = type === 'error' ? '🆘' : '👻';
     const pageIdString = this.page ? ` ${this.page.id} :` : '';
     const eventTypeString = this.event && this.event.action ? ` ${this.event.action} :` : ' Invoked :';
 
-    console.log(`${PLUGIN_NAME} ${logType}${pageIdString}${eventTypeString} ${message}`); // eslint-disable-line no-console
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`${PLUGIN_NAME} ${logType}${pageIdString}${eventTypeString} ${message}`); // eslint-disable-line no-console
+    }
   }
 
   /**
-   * @description Takes a string message and renders it as a Toast in the Sketch UI.
+   * @description Takes a string message and renders it as a Toast in the Figma UI.
    *
    * @kind function
    * @name toast

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -1,0 +1,236 @@
+import { hexToDecimalRgb } from './Tools';
+import {
+  COLORS,
+  FRAME_TYPES,
+  PLUGIN_IDENTIFIER,
+  PLUGIN_NAME,
+} from './constants';
+
+// --- private functions for drawing/positioning annotation elements in the Figma file
+
+/**
+ * @description Builds the rectangle shape styled as a bounding box.
+ *
+ * @kind function
+ * @name buildBoundingBox
+ * @param {Object} position The frame coordinates (`x`, `y`, `width`, and `height`) for the box.
+ * @param {Object} containerGroup The container group to draw within.
+ * @returns {Object} The Sketch ShapePath object for the box.
+ * @private
+ */
+const buildBoundingBox = (position, containerGroup?) => {
+  const colorHex = COLORS.style;
+  const colorOpactiy = '4d'; // 30% opacity
+
+  console.log('hello from build');
+  console.log(position);
+
+  const rect = figma.createRectangle();
+  const rectRgb = hexToDecimalRgb(colorHex);
+
+  rect.x = position.x;
+  rect.y = position.y;
+
+  rect.resize(position.width, position.height)
+  rect.fills = [{
+    type: 'SOLID',
+    color: { r: rectRgb.r, g: rectRgb.g, b: rectRgb.b },
+    opacity: 0.3,
+  }];
+  return rect;
+  // figma.currentPage.appendChild(rect);
+  // nodes.push(rect)
+
+  // find container position, relative to artboard
+  // const relativeGroupFrame = getPositionOnArtboard(containerGroup.sketchObject);
+
+  // // set x, y relative to container group and artboard
+  // const placementX = position.x - relativeGroupFrame.x;
+  // const placementY = position.y - relativeGroupFrame.y;
+
+  // // build the rounded rectangle
+  // const boundingBox = new ShapePath({
+  //   position: new Rectangle(placementX, placementY, position.width, position.height),
+  //   name: 'Bounding Box',
+  //   parent: containerGroup,
+  //   style: {
+  //     borders: [{
+  //       enabled: false,
+  //       thickness: 0,
+  //     }],
+  //     fills: [`${colorHex}${colorOpactiy}`], // i.e. #ff6655
+  //   },
+  // });
+
+  // return boundingBox;
+};
+
+/** WIP
+ * @description Takes a string representing the type of element getting painted and
+ * returns the name of the group used for that element.
+ *
+ * @kind function
+ * @name findFrame
+ * @param {string} elementType A string representing the type of element getting painted.
+ *
+ * @returns {string} The name of the group getting painted.
+ * @private
+ */
+const findFrame = (layer: any) => {
+  let { parent } = layer;
+
+  // loop through each parent and adjust the coordinates
+  if (parent) {
+    while (parent.type !== FRAME_TYPES.main) {
+      parent = parent.parent; // eslint-disable-line prefer-destructuring
+    }
+  }
+  return parent;
+};
+
+/**
+ * @description Takes a string representing the type of element getting painted and
+ * returns the name of the group used for that element.
+ *
+ * @kind function
+ * @name setGroupName
+ * @param {string} elementType A string representing the type of element getting painted.
+ *
+ * @returns {string} The name of the group getting painted.
+ * @private
+ */
+const setGroupName = (elementType: string) => {
+  let groupName = null;
+  switch (elementType) {
+    case 'boundingBox':
+      groupName = 'Bounding Boxes';
+      break;
+    case 'component':
+    case 'custom':
+      groupName = 'Component Annotations';
+      break;
+    case 'dimension':
+      groupName = 'Dimension Annotations';
+      break;
+    case 'spacing':
+      groupName = 'Spacing Annotations';
+      break;
+    case 'style':
+      groupName = 'Foundation Annotations';
+      break;
+    default:
+      groupName = 'Component Annotations';
+  }
+  return groupName;
+};
+
+/**
+ * @description Takes a string representing the type of element getting painted and
+ * returns the key used in document settings to represent data linked to the element.
+ *
+ * @kind function
+ * @name setGroupKey
+ * @param {string} elementType A string representing the type of element getting painted.
+ *
+ * @returns {string} The key representing the type of element getting painted.
+ * @private
+ */
+const setGroupKey = (elementType: string) => {
+  let groupKey = null;
+  switch (elementType) {
+    case 'boundingBox':
+      groupKey = 'boundingInnerGroupId';
+      break;
+    case 'component':
+    case 'custom':
+      groupKey = 'componentInnerGroupId';
+      break;
+    case 'dimension':
+      groupKey = 'dimensionInnerGroupId';
+      break;
+    case 'spacing':
+      groupKey = 'spacingInnerGroupId';
+      break;
+    case 'style':
+      groupKey = 'styleInnerGroupId';
+      break;
+    default:
+      groupKey = 'componentInnerGroupId';
+  }
+  return groupKey;
+};
+
+// --- main Painter class function
+/**
+ * @description A class to add elements to the Sketch file.
+ *
+ * @class
+ * @name Painter
+ *
+ * @constructor
+ *
+ * @property layer The layer in the Sketch file that we want to annotate or modify.
+ */
+export default class Painter {
+  layer: any;
+  frame: any;
+  page: any;
+  constructor({ for: layer, in: page }) {
+    this.layer = layer;
+    this.frame = findFrame(this.layer);
+    this.page = page;
+  }
+
+  /**
+   * @description Adds a semi-transparent rectangle to a specific artboard based on the parameters
+   * received in the `frame` object.
+   *
+   * @kind function
+   * @name addBoundingBox
+   * @param {Object} position The position coordinates (`x`, `y`, `width`, and `height`) for the box.
+   * @returns {Object} A result object container success/error status and log/toast messages.
+   */
+  addBoundingBox(position) {
+    const result = {
+      status: null,
+      messages: {
+        toast: null,
+        log: null,
+      },
+    };
+
+    // create or locate the container group
+    // const { innerContainerGroup } = setContainerGroups(
+    //   this.frame,
+    //   this.page,
+    //   'boundingBox',
+    // );
+
+    // draw the bounding box
+    // const boundingBox = buildBoundingBox(position, innerContainerGroup);
+    // const innerContainerGroup = figma.createFrame()
+    // innerContainerGroup.name = 'yolo';
+    // this.frame.appendChild(innerContainerGroup);
+    const boundingBox = buildBoundingBox(position);
+
+    const innerContainerGroup = figma.group([boundingBox], this.frame);
+    innerContainerGroup.x = position.x;
+    innerContainerGroup.y = position.y;
+    innerContainerGroup.name = 'yolo';
+
+    innerContainerGroup.appendChild(boundingBox);
+    // innerContainerGroup.appendChild(boundingBox);
+
+    if (!boundingBox) {
+      result.status = 'error';
+      result.messages.log = 'Failed to draw the bounding box for a selection';
+      result.messages.toast = 'Hmm… an error occured drawing that bounding box 😬';
+
+      return result;
+    }
+
+    result.status = 'success';
+    result.messages.log = `Bounding box drawn on “${this.frame.name}”`;
+    return result;
+  }
+}

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -200,7 +200,7 @@ export const createContainerGroup = (
   const groupKey = setGroupKey(groupType);
   const locked = groupType === 'topLevel';
 
-  // set up new container group layer on the artboard
+  // set up new container group layer on the frame
   const newInnerGroup = drawContainerGroup({
     name: groupName,
     position: { x: layer.x, y: layer.y },

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -1,3 +1,5 @@
+const hexRgb = require('hex-rgb');
+
 // --- helper functions
 
 /**
@@ -17,7 +19,7 @@
  */
 const updateArray = (
   key: string,
-  item: object,
+  item: any,
   array: Array<any>,
   action: string = 'add',
 ) => {
@@ -46,6 +48,30 @@ const updateArray = (
   return updatedArray;
 };
 
+/** WIP
+ * @description A reusable helper function to take an array and add or remove data from it
+ * based on a top-level key and a defined action.
+ * an action (`add` or `remove`).
+ *
+ * @kind function
+ * @name hexToDecimalRGB
+ * @param {string} key String representing the top-level area of the array to modify.
+ *
+ * @returns {Object} The modified array.
+ * @private
+ */
+const hexToDecimalRgb = (hexColor: string) => {
+  const rgbColor = hexRgb(hexColor);
+
+  const r = (rgbColor.red / 255);
+  const g = (rgbColor.green / 255);
+  const b = (rgbColor.blue / 255);
+
+  const decimalRgb = { r, g, b };
+  return decimalRgb;
+};
+
 export {
+  hexToDecimalRgb,
   updateArray,
 };

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -1,0 +1,51 @@
+// --- helper functions
+
+/**
+ * @description A reusable helper function to take an array and add or remove data from it
+ * based on a top-level key and a defined action.
+ * an action (`add` or `remove`).
+ *
+ * @kind function
+ * @name updateArray
+ * @param {string} key String representing the top-level area of the array to modify.
+ * @param {Object} item Object containing the new bit of data to add or
+ * remove (must include an `id` string for comparison).
+ * @param {Array} array The array to be modified.
+ * @param {string} action Constant string representing the action to take (`add` or `remove`).
+ * @returns {Object} The modified array.
+ * @private
+ */
+const updateArray = (
+  key: string,
+  item: object,
+  array: Array<any>,
+  action: string = 'add',
+) => {
+  const updatedArray = array;
+
+  if (action === 'add') {
+    if (!updatedArray[key]) {
+      updatedArray[key] = [];
+    }
+
+    updatedArray[key].push(item);
+  }
+
+  if (action === 'remove') {
+    let updatedItems = null;
+    // find the items updatedArray index of the item to remove
+    const itemIndex = updatedArray[key].findIndex(foundItem => (foundItem.id === item.id));
+
+    updatedItems = [
+      ...updatedArray[key].slice(0, itemIndex),
+      ...updatedArray[key].slice(itemIndex + 1),
+    ];
+
+    updatedArray[key] = updatedItems;
+  }
+  return updatedArray;
+};
+
+export {
+  updateArray,
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -21,6 +21,14 @@ const PLUGIN_IDENTIFIER = 'com.linkedin.figma.specter-plugin';
  */
 const PLUGIN_NAME = 'Specter';
 
+/** WIP
+ * @description The public-facing name for the plugin. This should match the
+ * `name` stated in manifset.json.
+ *
+ * @kind constant
+ * @name PLUGIN_NAME
+ * @type {string}
+ */
 const COLORS = {
   component: '#9966ff',
   custom: '#ff3399',
@@ -29,6 +37,27 @@ const COLORS = {
   style: '#ff6655',
 };
 
+/** WIP
+ * @description The public-facing name for the plugin. This should match the
+ * `name` stated in manifset.json.
+ *
+ * @kind constant
+ * @name PLUGIN_NAME
+ * @type {string}
+ */
+const FRAME_TYPES = {
+  main: 'FRAME',
+  group: 'GROUP',
+};
+
+/** WIP
+ * @description The public-facing name for the plugin. This should match the
+ * `name` stated in manifset.json.
+ *
+ * @kind constant
+ * @name PLUGIN_NAME
+ * @type {string}
+ */
 const GUI_SETTINGS = {
   default: {
     width: 140,
@@ -41,6 +70,7 @@ const CLOSE_PLUGIN_MSG = '_CLOSE_PLUGIN_';
 export {
   CLOSE_PLUGIN_MSG,
   COLORS,
+  FRAME_TYPES,
   GUI_SETTINGS,
   PLUGIN_IDENTIFIER,
   PLUGIN_NAME,

--- a/src/figma.d.ts
+++ b/src/figma.d.ts
@@ -1,3 +1,5 @@
+// Figma Plugin API version 1, update 1
+
 // Global variable with Figma's plugin API.
 declare const figma: PluginAPI
 declare const __html__: string
@@ -5,9 +7,10 @@ declare const __html__: string
 interface PluginAPI {
   readonly apiVersion: "1.0.0"
   readonly command: string
-  readonly root: DocumentNode
   readonly viewport: ViewportAPI
   closePlugin(message?: string): void
+
+  notify(message: string, options?: NotificationOptions): NotificationHandler
 
   showUI(html: string, options?: ShowUIOptions): void
   readonly ui: UIAPI
@@ -17,6 +20,7 @@ interface PluginAPI {
   getNodeById(id: string): BaseNode | null
   getStyleById(id: string): BaseStyle | null
 
+  readonly root: DocumentNode
   currentPage: PageNode
 
   readonly mixed: symbol
@@ -28,16 +32,26 @@ interface PluginAPI {
   createStar(): StarNode
   createVector(): VectorNode
   createText(): TextNode
-  createBooleanOperation(): BooleanOperationNode
   createFrame(): FrameNode
   createComponent(): ComponentNode
   createPage(): PageNode
   createSlice(): SliceNode
+  /**
+   * [DEPRECATED]: This API often fails to create a valid boolean operation. Use figma.union, figma.subtract, figma.intersect and figma.exclude instead.
+   */
+  createBooleanOperation(): BooleanOperationNode
 
   createPaintStyle(): PaintStyle
   createTextStyle(): TextStyle
   createEffectStyle(): EffectStyle
   createGridStyle(): GridStyle
+
+  // The styles are returned in the same order as displayed in the UI. Only
+  // local styles are returned. Never styles from team library.
+  getLocalPaintStyles(): PaintStyle[]
+  getLocalTextStyles(): TextStyle[]
+  getLocalEffectStyles(): EffectStyle[]
+  getLocalGridStyles(): GridStyle[]
 
   importComponentByKeyAsync(key: string): Promise<ComponentNode>
   importStyleByKeyAsync(key: string): Promise<BaseStyle>
@@ -53,6 +67,11 @@ interface PluginAPI {
 
   group(nodes: ReadonlyArray<BaseNode>, parent: BaseNode & ChildrenMixin, index?: number): FrameNode
   flatten(nodes: ReadonlyArray<BaseNode>, parent?: BaseNode & ChildrenMixin, index?: number): VectorNode
+
+  union(nodes: ReadonlyArray<BaseNode>, parent: BaseNode & ChildrenMixin, index?: number): BooleanOperationNode
+  subtract(nodes: ReadonlyArray<BaseNode>, parent: BaseNode & ChildrenMixin, index?: number): BooleanOperationNode
+  intersect(nodes: ReadonlyArray<BaseNode>, parent: BaseNode & ChildrenMixin, index?: number): BooleanOperationNode
+  exclude(nodes: ReadonlyArray<BaseNode>, parent: BaseNode & ChildrenMixin, index?: number): BooleanOperationNode
 }
 
 interface ClientStorageAPI {
@@ -60,18 +79,26 @@ interface ClientStorageAPI {
   setAsync(key: string, value: any): Promise<void>
 }
 
-type ShowUIOptions = {
+interface NotificationOptions {
+  timeout?: number,
+}
+
+interface NotificationHandler {
+  cancel: () => void,
+}
+
+interface ShowUIOptions {
   visible?: boolean,
   width?: number,
   height?: number,
 }
 
-type UIPostMessageOptions = {
-  targetOrigin?: string,
+interface UIPostMessageOptions {
+  origin?: string,
 }
 
-type OnMessageProperties = {
-  sourceOrigin: string,
+interface OnMessageProperties {
+  origin: string,
 }
 
 interface UIAPI {
@@ -161,13 +188,13 @@ interface ColorStop {
 }
 
 interface ImageFilters {
-  exposure?: number
-  contrast?: number
-  saturation?: number
-  temperature?: number
-  tint?: number
-  highlights?: number
-  shadows?: number
+  readonly exposure?: number
+  readonly contrast?: number
+  readonly saturation?: number
+  readonly temperature?: number
+  readonly tint?: number
+  readonly highlights?: number
+  readonly shadows?: number
 }
 
 interface SolidPaint {
@@ -297,7 +324,7 @@ interface VectorPath {
 
 type VectorPaths = ReadonlyArray<VectorPath>
 
-type LetterSpacing = {
+interface LetterSpacing {
   readonly value: number
   readonly unit: "PIXELS" | "PERCENT"
 }
@@ -340,7 +367,7 @@ interface Font {
 interface BaseNodeMixin {
   readonly id: string
   readonly parent: (BaseNode & ChildrenMixin) | null
-  name: string // Note: setting this also sets `autoRename` to false on TextNodes
+  name: string // Note: setting this also sets \`autoRename\` to false on TextNodes
   readonly removed: boolean
   toString(): string
   remove(): void
@@ -360,13 +387,13 @@ interface SceneNodeMixin {
 }
 
 interface ChildrenMixin {
-  readonly children: ReadonlyArray<BaseNode>
+  readonly children: ReadonlyArray<SceneNode>
 
-  appendChild(child: BaseNode): void
-  insertChild(index: number, child: BaseNode): void
+  appendChild(child: SceneNode): void
+  insertChild(index: number, child: SceneNode): void
 
-  findAll(callback?: (node: BaseNode) => boolean): ReadonlyArray<BaseNode>
-  findOne(callback: (node: BaseNode) => boolean): BaseNode | null
+  findAll(callback?: (node: SceneNode) => boolean): SceneNode[]
+  findOne(callback: (node: SceneNode) => boolean): SceneNode | null
 }
 
 interface ConstraintMixin {
@@ -426,7 +453,7 @@ interface CornerMixin {
 }
 
 interface ExportMixin {
-  exportSettings: ExportSettings[]
+  exportSettings: ReadonlyArray<ExportSettings>
   exportAsync(settings?: ExportSettings): Promise<Uint8Array> // Defaults to PNG format
 }
 
@@ -444,8 +471,16 @@ interface DefaultContainerMixin extends
 ////////////////////////////////////////////////////////////////////////////////
 // Nodes
 
-interface DocumentNode extends BaseNodeMixin, ChildrenMixin {
+interface DocumentNode extends BaseNodeMixin {
   readonly type: "DOCUMENT"
+
+  readonly children: ReadonlyArray<PageNode>
+
+  appendChild(child: PageNode): void
+  insertChild(index: number, child: PageNode): void
+
+  findAll(callback?: (node: (PageNode | SceneNode)) => boolean): Array<PageNode | SceneNode>
+  findOne(callback: (node: (PageNode | SceneNode)) => boolean): PageNode | SceneNode | null
 }
 
 interface PageNode extends BaseNodeMixin, ChildrenMixin, ExportMixin {
@@ -454,6 +489,8 @@ interface PageNode extends BaseNodeMixin, ChildrenMixin, ExportMixin {
 
   guides: ReadonlyArray<Guide>
   selection: ReadonlyArray<SceneNode>
+
+  backgrounds: ReadonlyArray<Paint>
 }
 
 interface FrameNode extends DefaultContainerMixin {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,26 @@
 // ++++++++++++++++++++++++++ Specter for Figma +++++++++++++++++++++++++++
+import Crawler from './Crawler';
+import Painter from './Painter';
 import { CLOSE_PLUGIN_MSG, GUI_SETTINGS } from './constants';
+
+/**
+ * @description A shared helper function to set up in-UI messages and the logger.
+ *
+ * @kind function
+ * @name assemble
+ * @param {Object} context The current context (event) received from Sketch.
+ * @returns {Object} Contains an object with the current document as a javascript object,
+ * a JSON object with documentData, a messenger instance, and a selection array (if applicable).
+ */
+const assemble = (context = null) => {
+  const page = context.currentPage;
+  const selection = context.currentPage.selection;
+
+  return {
+    page,
+    selection,
+  };
+};
 
 // GUI management -------------------------------------------------
 
@@ -103,11 +124,35 @@ const annotateMeasurement = (shouldTerminate: boolean): void => {
  * @returns {null} Shows a Toast in the UI if nothing is selected.
  */
 const drawBoundingBox = (shouldTerminate: boolean = true): void => {
+  const {
+    page,
+    selection,
+  } = assemble(figma);
+
   console.log('action: drawBoundingBox');
 
-  if (shouldTerminate) {
-    closeGUI();
+  // need a selected layer to annotate it
+  if (selection === null || selection.length === 0) {
+    // return messenger.alert('At least one layer must be selected');
+    console.log('notify here of empty selection');
   }
+
+  // grab the frame from the selection
+  const crawler = new Crawler({ for: selection });
+  const layer = crawler.first();
+  const position = crawler.position();
+  console.log(position);
+  const painter = new Painter({ for: layer, in: page });
+
+  // draw the bounding box (if position exists)
+  let paintResult = null;
+  if (position) {
+    paintResult = painter.addBoundingBox(position);
+  }
+
+  // if (shouldTerminate) {
+  //   closeGUI();
+  // }
   return null;
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 // ++++++++++++++++++++++++++ Specter for Figma +++++++++++++++++++++++++++
 import Crawler from './Crawler';
+import Messenger from './Messenger';
 import Painter from './Painter';
 import { CLOSE_PLUGIN_MSG, GUI_SETTINGS } from './constants';
 
@@ -15,8 +16,10 @@ import { CLOSE_PLUGIN_MSG, GUI_SETTINGS } from './constants';
 const assemble = (context = null) => {
   const page = context.currentPage;
   const selection = context.currentPage.selection;
+  const messenger = new Messenger({ for: context, in: page });
 
   return {
+    messenger,
     page,
     selection,
   };
@@ -125,6 +128,7 @@ const annotateMeasurement = (shouldTerminate: boolean): void => {
  */
 const drawBoundingBox = (shouldTerminate: boolean = true): void => {
   const {
+    messenger,
     page,
     selection,
   } = assemble(figma);

--- a/src/main.ts
+++ b/src/main.ts
@@ -195,7 +195,7 @@ try {
   main();
 } catch (e) {
   if (e === CLOSE_PLUGIN_MSG) {
-    // figma.closePlugin();
+    figma.closePlugin();
   } else {
     // If we caught any other kind of exception,
     // it's a real error and should be passed along.


### PR DESCRIPTION
Add the “Bounding Box” feature.

In adding this feature, ported over and modified `Messenger` and much of the layer/settings management work in `Painter` from [Specter for Sketch](https://github.com/linkedinlabs/specter-sketch). Some work in `Crawler` was also ported. Some key language differences: renamed `artboard` references to `frame`, and `frame` to `position` to more closely match the Figma API.

<img width="1035" alt="Screen Shot 2019-09-09 at 4 31 16 PM" src="https://user-images.githubusercontent.com/867428/64573194-49603700-d31f-11e9-8481-6cd47cf25fa3.png">
