### PR TITLE
Dimensions & Spacing

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
       "name": "Annotate",
         "menu": [
           {
-            "name": "Lookup Annotation",
+            "name": "Set Auto-Annotation",
             "command": "annotate"
           },
           {
@@ -26,8 +26,32 @@
         ]
     },
     {
-      "name": "Set Measurement",
-      "command": "measure"
+      "name": "Spacing & Dimensions",
+        "menu": [
+          {
+            "name": "Set Auto-Measurement",
+            "command": "measure"
+          },
+          {
+            "separator": true
+          },
+          {
+            "name": "Set Spacing: ← Left",
+            "command": "annotate-spacing-left"
+          },
+          {
+            "name": "Set Spacing: → Right",
+            "command": "annotate-spacing-right"
+          },
+          {
+            "name": "Set Spacing: ↑ Top",
+            "command": "annotate-spacing-top"
+          },
+          {
+            "name": "Set Spacing: ↓ Bottom",
+            "command": "annotate-spacing-bottom"
+          }
+        ]
     },
     {
       "name": "Draw Bounding Box",

--- a/src/App.ts
+++ b/src/App.ts
@@ -294,70 +294,64 @@ export default class App {
     messenger.handleResult(paintResult);
 
     if (this.shouldTerminate) {
-      this.closeGUI();
+      this.closeGUI(false);
     }
     return null;
   }
 
-  // /**
-  //  * @description Annotates the selection with the spacing number (“IS-X”) based on either
-  //  * the gap between the two layers or, if they are overlapping, the 4 directions of overlap
-  //  * (top, bottom, right, and left).
-  //  *
-  //  * @kind function
-  //  * @name annotateSpacingOnly
-  //  * @param {string} direction An optional string representing the annotation direction.
-  //  * Valid inputs are `top`, `bottom`, `right` (default), and `left`.
-  //  * @returns {null} Shows a Toast in the UI if nothing is selected or
-  //  * if more than two layers are selected.
-  //  */
-  // annotateSpacingOnly(direction: 'top' | 'bottom' | 'left' | 'right' = 'right') {
-  //   const {
-  //     messenger,
-  //     page,
-  //     selection,
-  //   } = assemble(figma);
+  /**
+   * @description Annotates the selection with the spacing number (“IS-X”) based on either
+   * the gap between the two layers or, if they are overlapping, the 4 directions of overlap
+   * (top, bottom, right, and left).
+   *
+   * @kind function
+   * @name annotateSpacingOnly
+   * @param {string} direction An optional string representing the annotation direction.
+   * Valid inputs are `top`, `bottom`, `right` (default), and `left`.
+   * @returns {null} Shows a Toast in the UI if nothing is selected or
+   * if more than two layers are selected.
+   */
+  annotateSpacingOnly(direction: 'top' | 'bottom' | 'left' | 'right' = 'right') {
+    const {
+      messenger,
+      page,
+      selection,
+    } = assemble(figma);
 
-  //   // need a selected layer to annotate it
-  //   if (selection === null || selection.length !== 2) {
-  //     return messenger.toast('Two layers must be selected');
-  //   }
+    // need a selected layer to annotate it
+    if (selection === null || selection.length !== 2) {
+      return messenger.toast('Two layers must be selected');
+    }
 
-  //   // grab the gap position from the selection
-  //   const crawler = new Crawler({ for: selection });
-  //   const layer = crawler.first();
+    // grab the gap position from the selection
+    const crawler = new Crawler({ for: selection });
+    const layer = crawler.first();
 
-  //   // set up Painter instance for the reference layer
-  //   const painter = new Painter({ for: layer, in: page });
+    // set up Painter instance for the reference layer
+    const painter = new Painter({ for: layer, in: page });
 
-  //   // draw the spacing annotation
-  //   // (if gap position exists or layers are overlapped)
-  //   let paintResult = null;
-  //   if (selection.length === 2) {
-  //     const overlapPositions = crawler.overlapPositions();
+    // draw the spacing annotation
+    // (if gap position exists or layers are overlapped)
+    let paintResult = null;
+    if (selection.length === 2) {
+      const overlapPositions = crawler.overlapPositions();
 
-  //     if (overlapPositions) {
-  //       const directions = [direction];
-  //       paintResult = painter.addOverlapMeasurements(overlapPositions, directions);
-  //     } else {
-  //       return messenger.toast('The selected layers need to overlap');
-  //     }
-  //   }
+      if (overlapPositions) {
+        const directions = [direction];
+        paintResult = painter.addOverlapMeasurements(overlapPositions, directions);
+      } else {
+        return messenger.toast('The selected layers need to overlap');
+      }
+    }
 
-  //   // read the response from Painter; log and display message(s)
-  //   messenger.handleResult(paintResult);
+    // read the response from Painter; log and display message(s)
+    messenger.handleResult(paintResult);
 
-  //   if (this.shouldTerminate) {
-  //     this.closeGUI();
-  //   }
-  //   return null;
-  // }
-  // // TKTK
-  // // set up some pre-defined `annotateSpacingOnly` aliases for `manifest` to use in the plugin menu
-  // // annotateSpacingTop() { this.annotateSpacingOnly('top') };
-  // // annotateSpacingBottom() { this.annotateSpacingOnly('bottom') };
-  // // annotateSpacingLeft() { this.annotateSpacingOnly('left') };
-  // // annotateSpacingRight() { this.annotateSpacingOnly('right') };
+    if (this.shouldTerminate) {
+      this.closeGUI(false);
+    }
+    return null;
+  }
 
   /**
    * @description Draws a semi-transparent “Bounding Box” around any selected elements.

--- a/src/App.ts
+++ b/src/App.ts
@@ -299,65 +299,65 @@ export default class App {
     return null;
   }
 
-  /**
-   * @description Annotates the selection with the spacing number (“IS-X”) based on either
-   * the gap between the two layers or, if they are overlapping, the 4 directions of overlap
-   * (top, bottom, right, and left).
-   *
-   * @kind function
-   * @name annotateSpacingOnly
-   * @param {string} direction An optional string representing the annotation direction.
-   * Valid inputs are `top`, `bottom`, `right` (default), and `left`.
-   * @returns {null} Shows a Toast in the UI if nothing is selected or
-   * if more than two layers are selected.
-   */
-  annotateSpacingOnly(direction: 'top' | 'bottom' | 'left' | 'right' = 'right') {
-    const {
-      messenger,
-      page,
-      selection,
-    } = assemble(figma);
+  // /**
+  //  * @description Annotates the selection with the spacing number (“IS-X”) based on either
+  //  * the gap between the two layers or, if they are overlapping, the 4 directions of overlap
+  //  * (top, bottom, right, and left).
+  //  *
+  //  * @kind function
+  //  * @name annotateSpacingOnly
+  //  * @param {string} direction An optional string representing the annotation direction.
+  //  * Valid inputs are `top`, `bottom`, `right` (default), and `left`.
+  //  * @returns {null} Shows a Toast in the UI if nothing is selected or
+  //  * if more than two layers are selected.
+  //  */
+  // annotateSpacingOnly(direction: 'top' | 'bottom' | 'left' | 'right' = 'right') {
+  //   const {
+  //     messenger,
+  //     page,
+  //     selection,
+  //   } = assemble(figma);
 
-    // need a selected layer to annotate it
-    if (selection === null || selection.length !== 2) {
-      return messenger.toast('Two layers must be selected');
-    }
+  //   // need a selected layer to annotate it
+  //   if (selection === null || selection.length !== 2) {
+  //     return messenger.toast('Two layers must be selected');
+  //   }
 
-    // // grab the gap position from the selection
-    // const crawler = new Crawler({ for: selection });
-    // const layer = crawler.first();
+  //   // grab the gap position from the selection
+  //   const crawler = new Crawler({ for: selection });
+  //   const layer = crawler.first();
 
-    // // set up Painter instance for the reference layer
-    // const painter = new Painter({ for: layer, in: page });
+  //   // set up Painter instance for the reference layer
+  //   const painter = new Painter({ for: layer, in: page });
 
-    // // draw the spacing annotation
-    // // (if gap position exists or layers are overlapped)
-    // let paintResult = null;
-    // if (selection.length === 2) {
-    //   const overlapPositions = crawler.overlapPositions();
+  //   // draw the spacing annotation
+  //   // (if gap position exists or layers are overlapped)
+  //   let paintResult = null;
+  //   if (selection.length === 2) {
+  //     const overlapPositions = crawler.overlapPositions();
 
-    //   if (overlapPositions) {
-    //     const directions = [direction];
-    //     paintResult = painter.addOverlapMeasurements(overlapPositions, directions);
-    //   } else {
-    //     return messenger.toast('The selected layers need to overlap');
-    //   }
-    // }
+  //     if (overlapPositions) {
+  //       const directions = [direction];
+  //       paintResult = painter.addOverlapMeasurements(overlapPositions, directions);
+  //     } else {
+  //       return messenger.toast('The selected layers need to overlap');
+  //     }
+  //   }
 
-    // // read the response from Painter; log and display message(s)
-    // messenger.handleResult(paintResult);
+  //   // read the response from Painter; log and display message(s)
+  //   messenger.handleResult(paintResult);
 
-    if (this.shouldTerminate) {
-      this.closeGUI();
-    }
-    return null;
-  }
-  // TKTK
-  // set up some pre-defined `annotateSpacingOnly` aliases for `manifest` to use in the plugin menu
-  // annotateSpacingTop() { this.annotateSpacingOnly('top') };
-  // annotateSpacingBottom() { this.annotateSpacingOnly('bottom') };
-  // annotateSpacingLeft() { this.annotateSpacingOnly('left') };
-  // annotateSpacingRight() { this.annotateSpacingOnly('right') };
+  //   if (this.shouldTerminate) {
+  //     this.closeGUI();
+  //   }
+  //   return null;
+  // }
+  // // TKTK
+  // // set up some pre-defined `annotateSpacingOnly` aliases for `manifest` to use in the plugin menu
+  // // annotateSpacingTop() { this.annotateSpacingOnly('top') };
+  // // annotateSpacingBottom() { this.annotateSpacingOnly('bottom') };
+  // // annotateSpacingLeft() { this.annotateSpacingOnly('left') };
+  // // annotateSpacingRight() { this.annotateSpacingOnly('right') };
 
   /**
    * @description Draws a semi-transparent “Bounding Box” around any selected elements.

--- a/src/App.ts
+++ b/src/App.ts
@@ -261,11 +261,11 @@ export default class App {
     } = assemble(figma);
 
     // need a selected layer to annotate it
-    if (selection === null || selection.count() > 2) {
+    if (selection === null || selection.length > 2) {
       return messenger.toast('One or two layers must be selected');
     }
 
-    // grab the gap frame from the selection
+    // grab the gap position from the selection
     const crawler = new Crawler({ for: selection });
     const layer = crawler.first();
 
@@ -273,20 +273,20 @@ export default class App {
     const painter = new Painter({ for: layer, in: page });
 
     // draw the spacing annotation
-    // (if gap frame exists or layers are overlapped)
+    // (if gap position exists or layers are overlapped)
     let paintResult = null;
-    if (selection.count() === 2) {
-      const gapFrame = crawler.gapFrame();
-      let overlapFrames = null;
-      if (gapFrame) {
-        paintResult = painter.addGapMeasurement(gapFrame);
+    if (selection.length === 2) {
+      const gapPosition = crawler.gapPosition();
+      let overlapPositions = null;
+      if (gapPosition) {
+        paintResult = painter.addGapMeasurement(gapPosition);
       } else {
-        overlapFrames = crawler.overlapFrames();
-        paintResult = painter.addOverlapMeasurements(overlapFrames);
+        overlapPositions = crawler.overlapPositions();
+        paintResult = painter.addOverlapMeasurements(overlapPositions);
       }
     }
 
-    if (selection.count() === 1) {
+    if (selection.length === 1) {
       paintResult = painter.addDimMeasurement();
     }
 
@@ -319,33 +319,33 @@ export default class App {
     } = assemble(figma);
 
     // need a selected layer to annotate it
-    if (selection === null || selection.count() !== 2) {
+    if (selection === null || selection.length !== 2) {
       return messenger.toast('Two layers must be selected');
     }
 
-    // grab the gap frame from the selection
-    const crawler = new Crawler({ for: selection });
-    const layer = crawler.first();
+    // // grab the gap position from the selection
+    // const crawler = new Crawler({ for: selection });
+    // const layer = crawler.first();
 
-    // set up Painter instance for the reference layer
-    const painter = new Painter({ for: layer, in: page });
+    // // set up Painter instance for the reference layer
+    // const painter = new Painter({ for: layer, in: page });
 
-    // draw the spacing annotation
-    // (if gap frame exists or layers are overlapped)
-    let paintResult = null;
-    if (selection.count() === 2) {
-      const overlapFrames = crawler.overlapFrames();
+    // // draw the spacing annotation
+    // // (if gap position exists or layers are overlapped)
+    // let paintResult = null;
+    // if (selection.length === 2) {
+    //   const overlapPositions = crawler.overlapPositions();
 
-      if (overlapFrames) {
-        const directions = [direction];
-        paintResult = painter.addOverlapMeasurements(overlapFrames, directions);
-      } else {
-        return messenger.toast('The selected layers need to overlap');
-      }
-    }
+    //   if (overlapPositions) {
+    //     const directions = [direction];
+    //     paintResult = painter.addOverlapMeasurements(overlapPositions, directions);
+    //   } else {
+    //     return messenger.toast('The selected layers need to overlap');
+    //   }
+    // }
 
-    // read the response from Painter; log and display message(s)
-    messenger.handleResult(paintResult);
+    // // read the response from Painter; log and display message(s)
+    // messenger.handleResult(paintResult);
 
     if (this.shouldTerminate) {
       this.closeGUI();
@@ -380,7 +380,7 @@ export default class App {
       return messenger.toast('At least one layer must be selected');
     }
 
-    // grab the frame from the selection
+    // grab the position from the selection
     const crawler = new Crawler({ for: selection });
     const layer = crawler.first();
     const position = crawler.position();

--- a/src/Crawler.ts
+++ b/src/Crawler.ts
@@ -1,4 +1,5 @@
 import { FRAME_TYPES } from './constants';
+import { getRelativeIndex } from './Tools';
 
 /**
  * @description A class to handle traversing an array of selected items and return useful items
@@ -119,7 +120,12 @@ export default class Crawler {
    * @returns {Object} The `x`, `y` coordinates and `width` and `height` of an entire selection.
    */
   position() {
-    const thePosition = {
+    const thePosition: {
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+    } = {
       x: null,
       y: null,
       width: 0,
@@ -127,18 +133,18 @@ export default class Crawler {
     };
 
     // set some intitial outer values to compare to
-    let outerX = 0;
-    let outerY = 0;
+    let outerX: number = 0;
+    let outerY: number = 0;
 
     // iterate through the selected layers and update the frame inner `x`/`y` values and
     // the outer `x`/`y` values
     this.all().forEach((layer) => {
-      const layerX = layer.x;
-      const layerY = layer.y;
-      const layerW = layer.width;
-      const layerH = layer.height;
-      const layerOuterX = layerX + layerW;
-      const layerOuterY = layerY + layerH;
+      const layerX: number = layer.x;
+      const layerY: number = layer.y;
+      const layerW: number = layer.width;
+      const layerH: number = layer.height;
+      const layerOuterX: number = layerX + layerW;
+      const layerOuterY: number = layerY + layerH;
 
       // set upper-left x
       if (
@@ -168,13 +174,376 @@ export default class Crawler {
     });
 
     // calculate the full `width`/`height` based on the inner and outer `x`/`y` values
-    const width = outerX - thePosition.x;
-    const height = outerY - thePosition.y;
+    const width: number = outerX - thePosition.x;
+    const height: number = outerY - thePosition.y;
 
     // set the new `width`/`height` values
     thePosition.width = width;
     thePosition.height = height;
 
     return thePosition;
+  }
+
+  /**
+   * @description Simulates position(), but for the space between two selected layers.
+   * It keeps the coordinates relative to the artboard, ignoring if some of the items are
+   * grouped inside other layers. It also adds an orientation `horizontal` or `vertical`
+   * based on the gap orientation. Assumes only 2 layers are selected.
+   *
+   * @kind function
+   * @name gapPosition
+   * @returns {Object} The `x`, `y` coordinates, `width`, `height`, and `orientation`
+   * of an entire selection. It also includes layer IDs (`layerAId` and `layerBId`)
+   * for the two layers used to calculated the gap position.
+   */
+  gapPosition() {
+    const thePosition: {
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+      orientation: 'horizontal' | 'vertical',
+      layerAId: string,
+      layerBId: string,
+    } = {
+      x: null,
+      y: null,
+      width: 0,
+      height: 0,
+      orientation: 'vertical',
+      layerAId: null,
+      layerBId: null,
+    };
+
+    const selection = this.array;
+
+    // set the layers to a default for comparisons
+    const firstIndex: 0 = 0;
+    let layerA = selection[firstIndex];
+    let layerB = selection[firstIndex];
+    // assume the gap orientation is vertical
+    let horizontalGap = false;
+
+    // find left-most (`layerA`) and right-most (`layerB`) layers
+    selection.forEach((layer) => {
+      if (layer.x < layerA.x) {
+        layerA = layer;
+      }
+
+      if (layer.x > layerB.x) {
+        layerB = layer;
+      }
+    });
+
+    if (layerA && layerB) {
+      let leftEdgeX = null; // lowest x within gap
+      let rightEdgeX = null; // highest x within gap
+      let topEdgeY = null;
+      let bottomEdgeY = null;
+      let positionHeight = null;
+
+      // make sure the layers are not overlapped (a gap exists)
+      if ((layerA.x + layerA.width) < layerB.x) {
+        // set the left/right edges of the gap
+        leftEdgeX = layerA.x + layerA.width; // lowest x within gap
+        rightEdgeX = layerB.x; // highest x within gap
+
+        const layerATopY = layerA.y;
+        const layerABottomY = layerA.y + layerA.height;
+        const layerBTopY = layerB.y;
+        const layerBBottomY = layerB.y + layerB.height;
+
+        if (layerBTopY >= layerATopY) {
+          // top of A is higher than top of B
+          if (layerABottomY >= layerBTopY) {
+            // top of B is higher than bottom of A
+            if (layerBBottomY >= layerABottomY) {
+              // bottom of A is higher than bottom of B
+              // decision: top edge is top of B; bottom edge is bottom of A
+              topEdgeY = layerBTopY;
+              bottomEdgeY = layerABottomY;
+            } else {
+              // decision: top edge is top of B; bottom edge is bottom of B
+              topEdgeY = layerBTopY;
+              bottomEdgeY = layerBBottomY;
+            }
+          } else {
+            // decision: top edge is bottom of A; bottom edge is top of B
+            topEdgeY = layerABottomY;
+            bottomEdgeY = layerBTopY;
+          }
+        } else if (layerBBottomY >= layerATopY) {
+          // top of A is higher than bottom of B
+          if (layerABottomY >= layerBBottomY) {
+            // bottom of B is higher than bottom of A
+            // decision: top edge is top of A; bottom edge is bottom of B
+            topEdgeY = layerATopY;
+            bottomEdgeY = layerBBottomY;
+          } else {
+            // decision: top edge is top of A; bottom edge is bottom of A
+            topEdgeY = layerATopY;
+            bottomEdgeY = layerABottomY;
+          }
+        } else {
+          // decision: top edge is bottom of B; bottom edge is top of A
+          topEdgeY = layerBBottomY;
+          bottomEdgeY = layerATopY;
+        }
+
+        // set position height
+        positionHeight = bottomEdgeY - topEdgeY;
+
+        // set the final position params
+        // cut final `y` in half by height to position annotation at mid-point
+        thePosition.x = leftEdgeX;
+        thePosition.y = topEdgeY + (positionHeight / 2);
+        thePosition.width = rightEdgeX - leftEdgeX;
+        thePosition.height = positionHeight;
+        thePosition.layerAId = layerA.id;
+        thePosition.layerBId = layerB.id;
+      } else {
+        horizontalGap = true;
+      }
+    }
+
+    // the gap is horizontal (if overlap does not exist)
+    if (horizontalGap) {
+      // find top-most (`layerA`) and bottom-most (`layerB`) layers
+      selection.forEach((layer) => {
+        if (layer.y < layerA.y) {
+          layerA = layer;
+        }
+
+        if (layer.y > layerB.y) {
+          layerB = layer;
+        }
+      });
+
+      let topEdgeY = null; // lowest y within gap
+      let bottomEdgeY = null; // highest y within gap
+      let leftEdgeX = null;
+      let rightEdgeX = null;
+      let positionWidth = null;
+
+      // make sure the layers are not overlapped (a gap exists)
+      if ((layerA.y + layerA.height) < layerB.y) {
+        // set the top/bottom edges of the gap
+        topEdgeY = layerA.y + layerA.height; // lowest y within gap
+        bottomEdgeY = layerB.y; // highest y within gap
+
+        // set initial layer values for comparison
+        const layerALeftX = layerA.x;
+        const layerARightX = layerA.x + layerA.width;
+        const layerBLeftX = layerB.x;
+        const layerBRightX = layerB.x + layerB.width;
+
+        if (layerBLeftX >= layerALeftX) {
+          // left-most of A is to the left of left-most of B
+          if (layerARightX >= layerBLeftX) {
+            // left-most of B is to the left of right-most of A
+            if (layerBRightX >= layerARightX) {
+              // right-most of A is to the left of right-most of B
+              // decision: left-most edge is left-most of B; right-most edge is right-most of A
+              leftEdgeX = layerBLeftX;
+              rightEdgeX = layerARightX;
+            } else {
+              // decision: left-most edge is left-most of B; right-most edge is right-most of B
+              leftEdgeX = layerBLeftX;
+              rightEdgeX = layerBRightX;
+            }
+          } else {
+            // decision: left-most edge is right-most of A; right-most edge is left-most of B
+            leftEdgeX = layerARightX;
+            rightEdgeX = layerBLeftX;
+          }
+        } else if (layerBRightX >= layerALeftX) {
+          // left-most of A is to the left of right-most of B
+          if (layerARightX >= layerBRightX) {
+            // right-most of B is to the left of right-most of A
+            // decision: left-most edge is left-most of A; right-most edge is right-most of B
+            leftEdgeX = layerALeftX;
+            rightEdgeX = layerBRightX;
+          } else {
+            // decision: left-most edge is left-most of A; right-most edge is right-most of A
+            leftEdgeX = layerALeftX;
+            rightEdgeX = layerARightX;
+          }
+        } else {
+          // decision: left-most edge is right-most of B; right-most edge is left-most of A
+          leftEdgeX = layerBRightX;
+          rightEdgeX = layerALeftX;
+        }
+
+        // set position height
+        positionWidth = rightEdgeX - leftEdgeX;
+
+        // set the final position params
+        // cut final `x` in half by width to position annotation at mid-point
+        thePosition.x = leftEdgeX + (positionWidth / 2);
+        thePosition.y = topEdgeY;
+        thePosition.width = positionWidth;
+        thePosition.height = bottomEdgeY - topEdgeY;
+        thePosition.orientation = 'horizontal';
+        thePosition.layerAId = layerA.id;
+        thePosition.layerBId = layerB.id;
+      }
+    }
+
+    // no gap exists
+    if (!thePosition.x) {
+      return null;
+    }
+
+    return thePosition;
+  }
+
+  /**
+   * @description Creates four separate positions for the spaces around two overlapping
+   * selected layers. It keeps the coordinates relative to the artboard, ignoring
+   * if some of the items are grouped inside other layers. It also adds an orientation
+   * `horizontal` or `vertical` based on the gap orientation. Assumes only 2 layers
+   * are selected.
+   *
+   * @kind function
+   * @name overlapPositions
+   * @returns {Object} The `top`, `bottom`, `right`, and `left` positions. Each position
+   * contains `x`, `y` coordinates, `width`, `height`, and `orientation`.
+   * The object also includes layer IDs (`layerAId` and `layerBId`)
+   * for the two layers used to calculated the overlapped areas.
+   */
+  overlapPositions() {
+    // use `gapPosition` to first ensure that the items do actually overlap
+    const gapPosition = this.gapPosition();
+
+    // if items do not overlap, cannot create an `overlapPosition`
+    if (gapPosition) {
+      return null;
+    }
+
+    // set the selection
+    const selection = this.array;
+
+    // set the layers to a default for comparisons
+    const firstIndex: 0 = 0;
+    let layerA = selection[firstIndex];
+    let layerB = selection[selection.length - 1];
+
+    // find bottom (`layerA`) and top (`layerB`) layers
+    let layerAIndex = getRelativeIndex(layerA);
+    let layerBIndex = getRelativeIndex(layerB);
+
+    // set the bottom layer to `layerA` and the top to `layerB`
+    // if `layerB` is currently the bottom, we have to flip them
+    selection.forEach((layer) => {
+      const layerIndex = getRelativeIndex(layer);
+
+      if (layerIndex > layerBIndex) {
+        layerB = layer;
+        layerBIndex = layerIndex;
+      }
+
+      if (layerIndex < layerAIndex) {
+        layerA = layer;
+        layerAIndex = layerIndex;
+      }
+    });
+
+    // we need a dominant layer to orient positioning;
+    // if both layers are exactly the same index, we cannot assume dominance.
+    // this should not happen, but layers might be selected from multiple artboards.
+    if (layerAIndex === layerBIndex) {
+      return null;
+    }
+
+    // -------- set positions - essentially defining rectangles in the overapped spaces
+    // between the too layers
+    // top
+    const topWidth = layerB.width;
+    const topHeight = layerB.y - layerA.y;
+    const topX = layerB.x;
+    const topY = layerA.y;
+    // bottom
+    const bottomWidth = layerB.width;
+    const bottomHeight = layerA.height - topHeight - layerB.height;
+    const bottomX = layerB.x;
+    const bottomY = layerA.y + topHeight + layerB.height;
+    // left
+    const leftWidth = layerB.x - layerA.x;
+    const leftHeight = layerB.height;
+    const leftX = layerA.x;
+    const leftY = layerB.y;
+    // right
+    const rightWidth = layerA.width - layerB.width - leftWidth;
+    const rightHeight = layerB.height;
+    const rightX = layerB.x + layerB.width;
+    const rightY = layerB.y;
+
+    // set the positions
+    const thePositions: {
+      top: {
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+        orientation: 'horizontal' | 'vertical',
+      },
+      bottom: {
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+        orientation: 'horizontal' | 'vertical',
+      },
+      right: {
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+        orientation: 'horizontal' | 'vertical',
+      },
+      left: {
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+        orientation: 'horizontal' | 'vertical',
+      },
+      layerAId: string,
+      layerBId: string,
+    } = {
+      top: {
+        x: topX,
+        y: topY,
+        width: topWidth,
+        height: topHeight,
+        orientation: 'horizontal',
+      },
+      bottom: {
+        x: bottomX,
+        y: bottomY,
+        width: bottomWidth,
+        height: bottomHeight,
+        orientation: 'horizontal',
+      },
+      right: {
+        x: rightX,
+        y: rightY,
+        width: rightWidth,
+        height: rightHeight,
+        orientation: 'vertical',
+      },
+      left: {
+        x: leftX,
+        y: leftY,
+        width: leftWidth,
+        height: leftHeight,
+        orientation: 'vertical',
+      },
+      layerAId: layerA.id,
+      layerBId: layerB.id,
+    };
+
+    // deliver the result
+    return thePositions;
   }
 }

--- a/src/Crawler.ts
+++ b/src/Crawler.ts
@@ -14,7 +14,7 @@ import { getRelativeIndex } from './Tools';
  * @property selectionArray The array of selected items.
  */
 export default class Crawler {
-  array: Array<any>;
+  array: Array<SceneNode>;
   constructor({ for: selectionArray }) {
     this.array = selectionArray;
   }

--- a/src/Crawler.ts
+++ b/src/Crawler.ts
@@ -456,7 +456,7 @@ export default class Crawler {
     }
 
     // -------- set positions - essentially defining rectangles in the overapped spaces
-    // between the too layers
+    // between the two layers
     // top
     const topWidth = layerB.width;
     const topHeight = layerB.y - layerA.y;

--- a/src/Identifier.ts
+++ b/src/Identifier.ts
@@ -196,7 +196,7 @@ const cleanName = (name: string): string => {
  */
 export default class Identifier {
   layer: any;
-  page: any;
+  page: PageNode;
   messenger: any;
   dispatcher?: Function;
   shouldTerminate: boolean;

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -534,10 +534,10 @@ const positionAnnotation = (
     let diamondLayerMidX: number = null;
     switch (frameEdge) {
       case 'left':
-        diamondLayerMidX = ((layerX - group.x) + ((layerWidth - 6) / 2));
+        diamondLayerMidX = ((layerX - group.x) + ((layerWidth + diamond.width + 6) / 2));
         break;
       case 'right':
-        diamondLayerMidX = ((layerX - group.x) + ((layerWidth - 6) / 2));
+        diamondLayerMidX = layerX - ((diamond.width + 6) / 2);
         break;
       default:
         diamondLayerMidX = diamond.x;
@@ -561,48 +561,21 @@ const positionAnnotation = (
     // re-position diamond
     diamond.x = diamondNewX;
     diamond.y = diamondNewY;
-
-    // re-size the annotation group frame
-    // group.y += 2;
-  }
-
-  // adjust diamond based on frame edge, if necessary
-  if (frameEdge && isMeasurement) {
-    switch (frameEdge) {
-      case 'bottom':
-        diamond.y = rectangle.height - diamond.height - offsetY;
-        break;
-      case 'left':
-        diamond.x = diamond.width / 2;
-        break;
-      case 'right':
-        diamond.x = rectangle.width - diamond.width - offsetX - 2;
-        break;
-      case 'top':
-        diamond.y = diamond.height / 2;
-        break;
-      default:
-        diamond.y = diamond.y;
-    }
   }
 
   // adjust the measure icon width for top-oriented annotations
   if (orientation === 'top' && icon) {
     icon.y += 26;
-    // icon.width = layerWidth;
     icon.resize(layerWidth, icon.height);
 
-    if (iconOffsetX > 0) { // TKTK
+    if (iconOffsetX > 0) {
       if (frameEdge === 'left') {
         icon.x -= icon.x;
       } else {
-        icon.x = (
-          frameWidth - group.x - icon.width
-        );
+        icon.x = frameWidth - icon.width;
       }
     } else {
       icon.x += (rectangle.width - layerWidth) / 2;
-      // icon.x += (icon.width + rectangle.width - layerWidth) / 2; // TKTK
     }
   }
 
@@ -627,7 +600,6 @@ const positionAnnotation = (
         // move the icon back to the top of the frame
         iconNew.y -= iconNew.y;
       } else {
-        // iconNew.y += (rectangle.height - layerHeight) / 2; // TKTK
         iconNew.y = layerPosition.y;
       }
     } else {

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -1062,9 +1062,9 @@ const removeAnnotation = (existingItemData: { id: string }) => {
  * @property page The page in the Figma file containing the corresponding `frame` and `layer`.
  */
 export default class Painter {
-  layer: any;
-  frame: any;
-  page: any;
+  layer: SceneNode;
+  frame: FrameNode;
+  page: PageNode;
   constructor({ for: layer, in: page }) {
     this.layer = layer;
     this.frame = findFrame(this.layer);

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -75,8 +75,7 @@ const buildAnnotation = (
   };
 
   if (isMeasurement) {
-    textPosition.x = 4;
-    textPosition.y = -1;
+    textPosition.x = 3;
   }
 
   // adjustment for two-line annotations
@@ -112,7 +111,7 @@ const buildAnnotation = (
   rectangle.bottomRightRadius = 2;
 
   // build the dangling diamond
-  const diamondOffset: number = (isMeasurement ? 19 : 30);
+  const diamondOffset: number = (isMeasurement ? 22 : 30);
   const diamond: any = figma.createRectangle();
   diamond.name = 'Diamond';
 
@@ -161,14 +160,12 @@ const buildAnnotation = (
   const rectangleWidth: number = textWidth + textPadding;
   rectangle.resize(rectangleWidth, rectangle.height);
 
-  // move the diamond to the mid-point of the rectangle
-  const diamondMidX: number = ((rectangleWidth - 6) / 2);
-  diamond.x = diamondMidX;
+  // move the text to the mid-point of the rectangle
+  text.x = rectangle.x + (textPadding / 2);
 
-  // set z-axis placement of all elements
-  // rectangle.moveToFront();
-  // text.index = rectangle.index + 1;
-  // diamond.index = rectangle.index - 1;
+  // move the diamond to the mid-point of the rectangle
+  const diamondMidX: number = ((rectangleWidth - 9) / 2);
+  diamond.x = diamondMidX;
 
   // icon TKTK
   // let icon = null;
@@ -391,15 +388,15 @@ const positionAnnotation = (
 
   // move diamand to left/right edge, if necessary
   if (orientation === 'left' || orientation === 'right') {
-    const diamondNewY: number = rectangle.y + (rectangle.height / 2) - 3;
+    const diamondNewY: number = rectangle.y + (rectangle.height / 2);
     let diamondNewX: number = null;
 
     if (orientation === 'left') {
       // move the diamond to the left mid-point of the layer to annotate
-      diamondNewX = rectangle.x + rectangle.width - 3;
+      diamondNewX = rectangle.x + rectangle.width - 4;
     } else {
       // move the diamond to the right mid-point of the layer to annotate
-      diamondNewX = rectangle.x - 3;
+      diamondNewX = rectangle.x - 4;
     }
 
     // re-position diamond
@@ -407,7 +404,7 @@ const positionAnnotation = (
     diamond.y = diamondNewY;
 
     // re-size the annotation group frame
-    group.y += 2;
+    // group.y += 2;
   }
 
   // adjust diamond based on frame edge, if necessary

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -90,7 +90,7 @@ const buildAnnotation = (
 
   // build the rounded rectangle
   const rectHeight: number = (isMeasurement ? 22 : 30) + rectTextBuffer;
-  const rectangle: any = figma.createRectangle();
+  const rectangle: RectangleNode = figma.createRectangle();
   rectangle.name = 'Rectangle';
 
   // position and size the rectangle
@@ -112,7 +112,7 @@ const buildAnnotation = (
 
   // build the dangling diamond
   const diamondOffset: number = (isMeasurement ? 22 : 30);
-  const diamond: any = figma.createRectangle();
+  const diamond: RectangleNode = figma.createRectangle();
   diamond.name = 'Diamond';
 
   // position and size the diamond
@@ -128,7 +128,7 @@ const buildAnnotation = (
   }];
 
   // create empty text layer
-  const text: any = figma.createText();
+  const text: TextNode = figma.createText();
 
   // style text layer
   text.fontName = TYPEFACES.primary;
@@ -200,7 +200,7 @@ const buildBoundingBox = (position) => {
   const colorOpactiy: number = 0.3; // 30% opacity
 
   // build and name the initial rectangle object
-  const boundingBox: any = figma.createRectangle();
+  const boundingBox: RectangleNode = figma.createRectangle();
   boundingBox.name = 'Bounding Box';
 
   // position and size the rectangle

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -986,7 +986,7 @@ export default class Painter {
     const groupName = `Annotation for ${layerName}`;
 
     // retrieve document settings
-    const pageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER) || {});
+    const pageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER) || null);
 
     // check if we have already annotated this element and remove the old annotation
     if (pageSettings && pageSettings.annotatedLayers) {
@@ -1066,7 +1066,7 @@ export default class Painter {
     };
 
     // update the `newPageSettings` array
-    let newPageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER) || {});
+    let newPageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER) || null);
     newPageSettings = updateArray(
       'annotatedLayers',
       newAnnotatedLayerSet,
@@ -1173,8 +1173,7 @@ export default class Painter {
     const layerName = this.layer.name;
 
     // retrieve document settings
-    const pageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER) || {});
-    let newPageSettings = pageSettings;
+    const pageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER) || null);
 
     // check if we have already annotated this element and remove the old annotation
     if (pageSettings && pageSettings.annotatedDimensions) {
@@ -1183,12 +1182,19 @@ export default class Painter {
         if (layerSet.originalId === layerId) {
           removeAnnotation(layerSet);
 
-          // remove the layerSet from the `newPageSettings` array
+          // remove the layerSet from the `pageSettings` array
+          let newPageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER));
           newPageSettings = updateArray(
             'annotatedDimensions',
             { id: layerSet.id },
             newPageSettings,
             'remove',
+          );
+
+          // commit the settings update
+          this.page.setPluginData(
+            PLUGIN_IDENTIFIER,
+            JSON.stringify(newPageSettings),
           );
         }
       });
@@ -1254,6 +1260,7 @@ export default class Painter {
     };
 
     // update the `newPageSettings` array
+    let newPageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER) || null);
     newPageSettings = updateArray(
       'annotatedDimensions',
       newAnnotatedDimensionSetWidth,
@@ -1352,8 +1359,7 @@ export default class Painter {
     const groupName = `Spacing for ${layerName} (${spacingPosition.direction})`;
 
     // retrieve document settings
-    const pageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER) || {});
-    let newPageSettings = pageSettings;
+    const pageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER) || null);
 
     // check if we have already annotated this element and remove the old annotation
     if (pageSettings && pageSettings.annotatedSpacings) {
@@ -1366,12 +1372,19 @@ export default class Painter {
         ) {
           removeAnnotation(layerSet);
 
-          // remove the layerSet from the `newPageSettings` array
+          // remove the layerSet from the `pageSettings` array
+          let newPageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER));
           newPageSettings = updateArray(
             'annotatedSpacings',
             { id: layerSet.id },
             newPageSettings,
             'remove',
+          );
+
+          // commit the settings update
+          this.page.setPluginData(
+            PLUGIN_IDENTIFIER,
+            JSON.stringify(newPageSettings),
           );
         }
       });
@@ -1438,6 +1451,7 @@ export default class Painter {
     };
 
     // update the `newPageSettings` array
+    let newPageSettings = JSON.parse(this.page.getPluginData(PLUGIN_IDENTIFIER) || null);
     newPageSettings = updateArray(
       'annotatedSpacings',
       newAnnotatedSpacingSet,

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -114,22 +114,12 @@ const findFrame = (layer: any) => {
  * @private
  */
 const getRelativeIndex = (layer): number => {
-  // need to reverse the selection array
-  // Figma gives it to us highest layer to lowest
-  const reverseSelection = (selection): Array<any> => {
-    const reversedSelection = [];
-    for (let i: number = selection.length - 1; i >= 0; i -= 1) {
-      reversedSelection.push(selection[i]);
-    }
-    return reversedSelection;
-  };
-
   const getIndex = (layerSet, comparisonLayer): number => {
     const index = layerSet.findIndex(node => node === comparisonLayer);
     return index;
   };
 
-  const parentChildren = reverseSelection(layer.parent.children);
+  const parentChildren = layer.parent.children;
   let layerIndex: number = getIndex(parentChildren, layer);
 
   const innerLayerIndex = layerIndex;
@@ -139,7 +129,7 @@ const getRelativeIndex = (layer): number => {
   // loop through each parent and adjust the coordinates
   if (parent) {
     while (parent.type === FRAME_TYPES.group) {
-      const parentParentChildren = reverseSelection(parent.parent.children);
+      const parentParentChildren = parent.parent.children;
       parentGroupIndex = getIndex(parentParentChildren, parent);
       parent = parent.parent; // eslint-disable-line prefer-destructuring
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import {
  *
  * @kind function
  * @name closeGUI
- * @param {booelan} suppress Attempt not to show users any lingering error messages.
+ * @param {boolean} suppress Attempt not to show users any lingering error messages.
  * Setting to `false` within `async` functions ensures the plugin actually closes.
  *
  * @throws {CLOSE_PLUGIN_MSG} Throws the command to close the plugin.
@@ -49,8 +49,8 @@ const showGUI = (): void => {
 
 /**
  * @description Takes a unique string (`type`) and calls the corresponding action
- * in the App class. Also does some housekeeping duties such as pre-loading typefaces,
- * logging errors, or managing the GUI.
+ * in the App class. Also does some housekeeping duties such as pre-loading typefaces
+ * and managing the GUI.
  *
  * @kind function
  * @name dispatcher
@@ -74,8 +74,8 @@ const dispatcher = (action: {
     showGUI,
   });
 
+  // run the action in the App class based on type
   const runAction = (actionType: string) => {
-    // run the action in the App class based on type
     switch (actionType) {
       case 'annotate':
         app.annotateLayer();
@@ -106,6 +106,7 @@ const dispatcher = (action: {
     }
   };
 
+  // load the typeface and then run the action
   const runActionWithTypefaces = async (actionType: string) => {
     // typefaces should be loaded before running action
     await figma.loadFontAsync(TYPEFACES.primary);

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,6 +83,18 @@ const dispatcher = (action: {
       case 'annotate-custom':
         app.annotateLayerCustom();
         break;
+      case 'annotate-spacing-left':
+        app.annotateSpacingOnly('left');
+        break;
+      case 'annotate-spacing-right':
+        app.annotateSpacingOnly('right');
+        break;
+      case 'annotate-spacing-top':
+        app.annotateSpacingOnly('top');
+        break;
+      case 'annotate-spacing-bottom':
+        app.annotateSpacingOnly('bottom');
+        break;
       case 'bounding':
         app.drawBoundingBox();
         break;

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,41 +74,32 @@ const dispatcher = (action: {
     showGUI,
   });
 
-  const runAnnotate = async () => {
-    // typefaces should be loaded before annotating with text
-    await figma.loadFontAsync(TYPEFACES.primary);
-    await app.annotateLayer();
+  const runAction = (actionType: string) => {
+    // run the action in the App class based on type
+    switch (actionType) {
+      case 'annotate':
+        app.annotateLayer();
+        break;
+      case 'annotate-custom':
+        app.annotateLayerCustom();
+        break;
+      case 'bounding':
+        app.drawBoundingBox();
+        break;
+      case 'measure':
+        app.annotateMeasurement();
+        break;
+      default:
+        showGUI();
+    }
   };
 
-  const runAnnotateCustom = async () => {
-    // typefaces should be loaded before annotating with text
+  const runActionWithTypefaces = async (actionType: string) => {
+    // typefaces should be loaded before running action
     await figma.loadFontAsync(TYPEFACES.primary);
-    await app.annotateLayerCustom();
+    await runAction(actionType);
   };
-
-  const runAnnotateMeasurement = async () => {
-    // typefaces should be loaded before annotating with text
-    await figma.loadFontAsync(TYPEFACES.primary);
-    await app.annotateMeasurement();
-  };
-
-  // run the action in the App class based on type
-  switch (action.type) {
-    case 'annotate':
-      runAnnotate();
-      break;
-    case 'annotate-custom':
-      runAnnotateCustom();
-      break;
-    case 'bounding':
-      app.drawBoundingBox();
-      break;
-    case 'measure':
-      runAnnotateMeasurement();
-      break;
-    default:
-      showGUI();
-  }
+  runActionWithTypefaces(action.type);
 
   return null;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,6 +86,12 @@ const dispatcher = (action: {
     await app.annotateLayerCustom();
   };
 
+  const runAnnotateMeasurement = async () => {
+    // typefaces should be loaded before annotating with text
+    await figma.loadFontAsync(TYPEFACES.primary);
+    await app.annotateMeasurement();
+  };
+
   // run the action in the App class based on type
   switch (action.type) {
     case 'annotate':
@@ -98,7 +104,7 @@ const dispatcher = (action: {
       app.drawBoundingBox();
       break;
     case 'measure':
-      app.annotateMeasurement();
+      runAnnotateMeasurement();
       break;
     default:
       showGUI();


### PR DESCRIPTION
Add the “Dimensions” and “Spacing” annotation features.

Among other bits, ported over `gapPosition` and `overlapPositions` to `Crawler`, and `buildMeasureIcon`, `retrieveSpacingValue`, `addDimMeasurement`, and `addGapMeasurement` to `Painter`.

Figma handles z-index differently from Sketch, so `getRelativeIndex` is added to `Tools`.

<img width="710" alt="Screen Shot 2019-10-01 at 12 53 51 PM" src="https://user-images.githubusercontent.com/867428/65995509-8a44fa80-e44a-11e9-801d-c7451e283ce3.png">
