### PR TITLE
Closing Plugin: Remove Legacy method

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -150,7 +150,7 @@ export default class App {
 
               // close the GUI if it started closed
               if (this.shouldTerminate && !shouldTerminateLocal) {
-                this.closeGUI(false);
+                this.closeGUI();
               }
             };
 
@@ -173,7 +173,7 @@ export default class App {
     });
 
     if (shouldTerminateLocal) {
-      this.closeGUI(false);
+      this.closeGUI();
     }
     return null;
   }
@@ -246,7 +246,7 @@ export default class App {
       }
 
       if (this.shouldTerminate) {
-        this.closeGUI(false);
+        this.closeGUI();
       }
 
       return null;
@@ -311,7 +311,7 @@ export default class App {
     messenger.handleResult(paintResult);
 
     if (this.shouldTerminate) {
-      this.closeGUI(false);
+      this.closeGUI();
     }
     return null;
   }
@@ -365,7 +365,7 @@ export default class App {
     messenger.handleResult(paintResult);
 
     if (this.shouldTerminate) {
-      this.closeGUI(false);
+      this.closeGUI();
     }
     return null;
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -85,17 +85,7 @@ const GUI_SETTINGS = {
   },
 };
 
-/**
- * @description A unique message that will cause the plugin to shut-down.
- *
- * @kind constant
- * @name CLOSE_PLUGIN_MSG
- * @type {string}
- */
-const CLOSE_PLUGIN_MSG = '_CLOSE_PLUGIN_';
-
 export {
-  CLOSE_PLUGIN_MSG,
   COLORS,
   FRAME_TYPES,
   GUI_SETTINGS,

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,18 +13,13 @@ import {
  *
  * @kind function
  * @name closeGUI
- * @param {boolean} suppress Attempt not to show users any lingering error messages.
- * Setting to `false` within `async` functions ensures the plugin actually closes.
  *
- * @throws {CLOSE_PLUGIN_MSG} Throws the command to close the plugin.
+ * @returns {null}
  */
-const closeGUI = (suppress: boolean = true): void => {
-  if (suppress) {
-    // close the UI while suppressing error messages
-    throw CLOSE_PLUGIN_MSG;
-  }
+const closeGUI = (): void => {
   // close the UI without suppressing error messages
-  return figma.closePlugin();
+  figma.closePlugin();
+  return null;
 };
 
 /**
@@ -151,24 +146,5 @@ const main = (): void => {
   };
 };
 
-/**
- * @description Listens for the command to close/shut down the plugin in a way that prevents
- * users from seeing unnecessary errors in the UI (recommended in the Figma docs).
- * [More info]{@link https://www.figma.com/plugin-docs/api/properties/figma-closeplugin//}
- *
- * @kind try...catch
- * @returns {null}
- * @throws {e} If the event is not the `CLOSE_PLUGIN_MSG`, it is thrown.
- */
-// watch for close in a way that prevents unnecessary errors in the UI
-try {
-  main();
-} catch (err) {
-  if (err === CLOSE_PLUGIN_MSG) {
-    figma.closePlugin();
-  } else {
-    // If we caught any other kind of exception,
-    // it's a real error and should be passed along.
-    throw err;
-  }
-}
+// run main as default
+main();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,6 @@
 // ++++++++++++++++++++++++++ Specter for Figma +++++++++++++++++++++++++++
 import App from './App';
-import {
-  CLOSE_PLUGIN_MSG,
-  GUI_SETTINGS,
-  TYPEFACES,
-} from './constants';
+import { GUI_SETTINGS, TYPEFACES } from './constants';
 
 // GUI management -------------------------------------------------
 


### PR DESCRIPTION
Removes a method of closing the plugin ([outlined here](https://www.figma.com/plugin-docs/api/properties/figma-closeplugin/)) that is no longer supported because the Figma plugin runtime no longer supports throwing errors.

Residual affect: fixes an issue where the Bounding Box menu command was not properly terminating.