### PR TITLE
Identifier: Annotation Fixes & Improvements

### DIFF
--- a/src/Identifier.ts
+++ b/src/Identifier.ts
@@ -1,6 +1,7 @@
 import {
   getLayerSettings,
   isInternal,
+  isVisible,
   resizeGUI,
   setLayerSettings,
   toSentenceCase,
@@ -289,7 +290,7 @@ const parseOverrides = (layer: any, workingName: string = null): string => {
 
   // iterate available inner layers - based on legacy Lingo naming schemes and may break.
   layer.findOne((node) => {
-    if (node.visible) {
+    if (isVisible(node)) {
       // current override full name
       const overrideTypeName: string = node.name;
 

--- a/src/Identifier.ts
+++ b/src/Identifier.ts
@@ -300,9 +300,11 @@ const parseOverrides = (layer: any, workingName: string = null): string => {
       const overrideName: string = cleanName(node.name);
 
       if (overrideName) {
+        let overrideValueName: string = null;
         // look for Icon overrides - based on parsing the text of an `overrideTypeName` and
         // making some comparisons and exceptions – if the override name exists in the
         // master component, we ignore it as it’s likely not an actual override
+        // these are mainly legacy checks from the Sketch / Lingo (Art Deco) system
         if (
           overrideTypeName.toLowerCase().includes('icon')
           && !overrideTypeName.toLowerCase().includes('color')
@@ -312,9 +314,22 @@ const parseOverrides = (layer: any, workingName: string = null): string => {
           && !layer.masterComponent.findOne(mcNode => mcNode.name === overrideTypeName)
         ) {
           // default icon name (usually last element of the name, separated by “/”)
-          let overrideValueName: string = overrideName.split(/(?:[^w])(\/)/).pop();
+          overrideValueName = overrideName.split(/(?:[^w])(\/)/).pop();
           overrideValueName = overrideValueName.replace(`${workingName}`, '');
+        }
 
+        // newer check for Placeholder parent container
+        if (!overrideValueName) {
+          if (
+            node.parent
+            && cleanName(node.parent.name).toLowerCase().includes('placeholder')
+            && !cleanName(node.name).toLowerCase().includes('placeholder')
+          ) {
+            overrideValueName = cleanName(node.name);
+          }
+        }
+
+        if (overrideValueName) {
           // update `overridesText`
           const existingIndex: number = overridesText.findIndex(text => text === overrideValueName);
           if (existingIndex < 0) {

--- a/src/Identifier.ts
+++ b/src/Identifier.ts
@@ -118,6 +118,8 @@ const checkNameForType = (name: string): 'component' | 'style' => {
  * @private
  */
 const cleanName = (name: string): string => {
+  if (!name.trim()) { return 'Unknown'; }
+
   let cleanedName: string = name;
 
   // only apply changes to internal builds
@@ -132,7 +134,7 @@ const cleanName = (name: string): string => {
     }
 
     // otherwise, fall back to the full layer name
-    cleanedName = !cleanedName ? name : cleanedName;
+    cleanedName = !cleanedName.trim() ? name : cleanedName;
   }
 
   return cleanedName;

--- a/src/Identifier.ts
+++ b/src/Identifier.ts
@@ -127,7 +127,7 @@ const cleanName = (name: string): string => {
     if (isLegacyByName(name)) {
       // take only the last segment of the name (after a “/”, if available)
       // ignore segments that begin with a “w” as-in “…Something w/ Icon”
-      cleanedName = cleanedName.split(/(?:[^w])(\/)/).pop();
+      cleanedName = cleanedName.split(/(?:[^w|^\s])(\/)/).pop();
     } else {
       cleanedName = cleanedName.replace('☾ ', '');
       cleanedName = cleanedName.replace('☼ ', '');

--- a/src/Identifier.ts
+++ b/src/Identifier.ts
@@ -127,10 +127,10 @@ const cleanName = (name: string): string => {
     if (isLegacyByName(name)) {
       // take only the last segment of the name (after a “/”, if available)
       // ignore segments that begin with a “w” as-in “…Something w/ Icon”
-      cleanedName = name.split(/(?:[^w])(\/)/).pop();
+      cleanedName = cleanedName.split(/(?:[^w])(\/)/).pop();
     } else {
-      cleanedName = name.replace('☾ ', '');
-      cleanedName = name.replace('☼ ', '');
+      cleanedName = cleanedName.replace('☾ ', '');
+      cleanedName = cleanedName.replace('☼ ', '');
     }
 
     // otherwise, fall back to the full layer name

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -301,6 +301,30 @@ const isInternal = (): boolean => {
   return buildIsInternal;
 };
 
+/**
+ * @description Check if a node (or any of its parents) are hidden and returns false if they are.
+ *
+ * @kind function
+ * @name isVisible
+ *
+ * @param {Object} node A Figma `SceneNode` object.
+ *
+ * @returns {boolean} `true` if the build is internal, `false` if it is not.
+ */
+const isVisible = (node: SceneNode): boolean => {
+  // if original node is hidden, no need to proceed
+  if (!node.visible) { return false; }
+
+  if (
+    node.parent.type !== 'PAGE'
+    && node.parent.type !== 'DOCUMENT'
+  ) {
+    return isVisible(node.parent);
+  }
+
+  return true;
+};
+
 export {
   findFrame,
   loadFirstAvailableFontAsync,
@@ -308,6 +332,7 @@ export {
   getRelativeIndex,
   hexToDecimalRgb,
   isInternal,
+  isVisible,
   resizeGUI,
   setLayerSettings,
   toSentenceCase,


### PR DESCRIPTION
Improvements to `Identifier`:

* Better prevent hidden layers from throwing an error
* Prevent components or layers with blank names (spaces) from throwing an error
* Better icon override handling for Mercado components
* Fix ☾/☼ substitution