### PR TITLE
Multi Bounding Box

### DIFF
--- a/manifest.example.json
+++ b/manifest.example.json
@@ -54,8 +54,17 @@
         ]
     },
     {
-      "name": "Draw Bounding Box",
-      "command": "bounding"
+      "name": "Bounding Boxes",
+        "menu": [
+          {
+            "name": "Draw Bounding Box",
+            "command": "bounding"
+          },
+          {
+            "name": "Draw Multiple Bounding Boxes",
+            "command": "bounding-multi"
+          }
+        ]
     }
   ]
 }

--- a/src/App.ts
+++ b/src/App.ts
@@ -399,7 +399,7 @@ export default class App {
    *
    * @returns {null} Shows a Toast in the UI if nothing is selected.
    */
-  drawBoundingBox() {
+  drawBoundingBox(type: 'single' | 'multiple' = 'single') {
     const {
       messenger,
       page,

--- a/src/App.ts
+++ b/src/App.ts
@@ -392,14 +392,19 @@ export default class App {
   }
 
   /**
-   * @description Draws a semi-transparent “Bounding Box” around any selected elements.
+   * @description Draws semi-transparent “Bounding Box(es)” around any selected nodes.
+   * The `type` parameter determines if a single box is drawn, incorporating all selected
+   * nodes (`single`), or if a box is drawn around each individual node (`multiple`).
    *
    * @kind function
-   * @name drawBoundingBox
+   * @name drawBoundingBoxes
+   *
+   * @param {string} type Use `single` for a box around the entire selection or `multiple`
+   * for individual boxes around each selected node.
    *
    * @returns {null} Shows a Toast in the UI if nothing is selected.
    */
-  drawBoundingBox(type: 'single' | 'multiple' = 'single') {
+  drawBoundingBoxes(type: 'single' | 'multiple' = 'single') {
     const {
       messenger,
       page,

--- a/src/App.ts
+++ b/src/App.ts
@@ -412,26 +412,39 @@ export default class App {
       return messenger.toast('At least one layer must be selected');
     }
 
-    // grab the position from the selection
-    const crawler = new Crawler({ for: selection });
-    const layer = crawler.first();
-    const positionResult = crawler.position();
+    const drawSingleBox = (nodes) => {
+      // grab the position from the selection
+      const crawler = new Crawler({ for: nodes });
 
-    // read the response from Crawler; log and display message(s)
-    messenger.handleResult(positionResult);
+      const layer = crawler.first();
+      const positionResult = crawler.position();
 
-    if (positionResult.status === 'success' && positionResult.payload) {
-      const position = positionResult.payload;
-      const painter = new Painter({ for: layer, in: page });
+      // read the response from Crawler; log and display message(s)
+      messenger.handleResult(positionResult);
 
-      // draw the bounding box (if position exists)
-      let paintResult = null;
-      if (position) {
-        paintResult = painter.addBoundingBox(position);
+      if (positionResult.status === 'success' && positionResult.payload) {
+        const position = positionResult.payload;
+        const painter = new Painter({ for: layer, in: page });
+
+        // draw the bounding box (if position exists)
+        let paintResult = null;
+        if (position) {
+          paintResult = painter.addBoundingBox(position);
+        }
+
+        // read the response from Painter; log and display message(s)
+        messenger.handleResult(paintResult);
       }
+    };
 
-      // read the response from Painter; log and display message(s)
-      messenger.handleResult(paintResult);
+    // set individual boxes for each selected node or set a single box
+    // that covers all nodes in the selection
+    if (type === 'multiple') {
+      selection.forEach((node: SceneNode) => {
+        drawSingleBox([node]); // expects an array
+      });
+    } else {
+      drawSingleBox(selection);
     }
 
     if (this.shouldTerminate) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,6 +90,9 @@ const dispatcher = (action: {
       case 'bounding':
         app.drawBoundingBox();
         break;
+      case 'bounding-multi':
+        app.drawBoundingBox('multiple');
+        break;
       case 'measure':
         app.annotateMeasurement();
         break;

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,10 +88,10 @@ const dispatcher = (action: {
         app.annotateSpacingOnly('bottom');
         break;
       case 'bounding':
-        app.drawBoundingBox();
+        app.drawBoundingBoxes();
         break;
       case 'bounding-multi':
-        app.drawBoundingBox('multiple');
+        app.drawBoundingBoxes('multiple');
         break;
       case 'measure':
         app.annotateMeasurement();


### PR DESCRIPTION
Adds a new menu command that will draw individual bounding boxes around each separate node in a selection (`multiple`) vs the original default (`single`) that draws a single bounding box encompassing the entire selection.