### PR TITLE
Labels: Painter Cleanup + Move Node Tracking/Repair

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -536,19 +536,19 @@ const refreshAnnotations = (
   return null;
 };
 
-/** WIP
- * @description Takes a node and locates its current Keystop data (position and keys), if
- * it exists. The data is located through the node’s top-level frame. Returns an object
- * formatted to pass along to the UI.
+/**
+ * @description Compares current tracking data for Keystop and Label nodes against the nodes
+ * themselves. If the nodes have changed size/position, we update the node’s corresponding
+ * annotation. If the node has not changed, but its annotation is missing, we re-paint it.
  *
  * @kind function
  * @name diffChanges
  *
- * @param {Object} node A SceneNode to check for Keystop data.
+ * @param {string} nodeType The type of annotations to diff. Currently: `keystop` or `label`.
+ * @param {Object} options An options bundle that contains the current `selection`, current `page`,
+ * an initiated `messenger`, and the `isMercadoMode` boolean.
  *
- * @returns {Object} An object formatted for the UI including `hasStop`, a boolean indicating
- * the presence of a keystop, the current position if the stop exists, and any keys (as an array),
- * if they exist.
+ * @returns {null}
  */
 const diffChanges = (
   nodeType: 'keystop' | 'label',
@@ -600,6 +600,8 @@ const diffChanges = (
     };
     repairBrokenLinks(nodeType, repairOptions);
   });
+
+  return null;
 };
 
 /** WIP
@@ -1802,7 +1804,8 @@ export default class App {
         return null;
     }
 
-    // ---------- track and re-draw annotations for nodes that have moved/changed
+    // ---------- track and re-draw annotations for nodes that have moved/changed/damaged
+    // currently we only track/repair for Labels and Keystops
     const diffChangesFor: Array<'keystop' | 'label'> = ['keystop', 'label'];
     const diffChangesOptions = {
       isMercadoMode,

--- a/src/App.ts
+++ b/src/App.ts
@@ -219,7 +219,7 @@ const repairBrokenLinks = (
             });
 
             // re-draw the annotation
-            const painterResult = nodeType === 'keystop' ? painter.addKeystop() : painter.addLabel();
+            const painterResult = painter.addStop(nodeType);
             messenger.handleResult(painterResult, true);
           }
         }
@@ -486,7 +486,7 @@ const refreshAnnotations = (
       });
 
       // re-draw the annotation
-      const painterResult = nodeType === 'keystop' ? painter.addKeystop() : painter.addLabel();
+      const painterResult = painter.addStop(nodeType);
       messenger.handleResult(painterResult, true);
 
       if (painterResult.status === 'error') {
@@ -1060,7 +1060,7 @@ export default class App {
         // draw the annotation (if the text exists)
         let paintResult = null;
         if (hasText) {
-          paintResult = nodeType === 'keystop' ? painter.addKeystop() : painter.addLabel();
+          paintResult = painter.addStop(nodeType);
         }
 
         // read the response from Painter; if it was unsuccessful, log and display the error

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -2222,7 +2222,7 @@ export default class Painter {
       type: annotationType,
     });
 
-    // set individual key annotations for keystops
+    // set individual `keys` annotations for keystops
     const auxAnnotations: Array<FrameNode> = [];
     if (nodeData.keys && nodeData.keys.length > 0) {
       nodeData.keys.forEach((keyEntry) => {
@@ -2254,7 +2254,7 @@ export default class Painter {
       annotationName,
       annotationBundle,
       nodePosition,
-      'keystop',
+      'keystop', // tktk - hardcoded to keystop for now
     );
     const initialX = baseAnnotationNode.x;
     const initialY = baseAnnotationNode.y;
@@ -2303,9 +2303,13 @@ export default class Painter {
       nodePosition,
     };
 
+    // set data types
+    const annotationsDataType = nodeType === 'keystop' ? DATA_KEYS.keystopAnnotations : DATA_KEYS.labelAnnotations;
+    const linkIdDataType = nodeType === 'keystop' ? DATA_KEYS.keystopLinkId : DATA_KEYS.labelLinkId;
+
     // update the `trackingSettings` array
     const trackingDataRaw = JSON.parse(
-      this.page.getPluginData(DATA_KEYS.keystopAnnotations) || null,
+      this.page.getPluginData(annotationsDataType) || null,
     );
     let trackingData: Array<PluginNodeTrackingData> = [];
     if (trackingDataRaw) {
@@ -2322,7 +2326,7 @@ export default class Painter {
 
     // commit the `trackingData` update
     this.page.setPluginData(
-      DATA_KEYS.keystopAnnotations,
+      annotationsDataType,
       JSON.stringify(trackingData),
     );
 
@@ -2332,7 +2336,7 @@ export default class Painter {
       role: 'node',
     };
     this.node.setPluginData(
-      DATA_KEYS.keystopLinkId,
+      linkIdDataType,
       JSON.stringify(nodeLinkData),
     );
 
@@ -2342,7 +2346,7 @@ export default class Painter {
       role: 'annotation',
     };
     annotationNode.setPluginData(
-      DATA_KEYS.keystopLinkId,
+      linkIdDataType,
       JSON.stringify(annotatedLinkData),
     );
 

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -2163,16 +2163,16 @@ export default class Painter {
     return result;
   }
 
-  /**
+  /** WIP
    * @description Builds a Keystop Annotation in Figma. Expects keystop node data to be
    * available (`annotationText` and potential `keys` for auxilary annotations).
    *
    * @kind function
-   * @name addKeystop
+   * @name addStop
    *
    * @returns {Object} A result object container success/error status and log/toast messages.
    */
-  addKeystop() {
+  addStop(nodeType: 'keystop' | 'label') {
     const result: {
       status: 'error' | 'success',
       messages: {
@@ -2187,10 +2187,11 @@ export default class Painter {
       },
     };
 
-    result.messages.log = `Draw the keyboard stop annotation for “${this.node.name}”`;
+    result.messages.log = `Draw the ${nodeType} stop annotation for “${this.node.name}”`;
 
     // retrieve the node data with our annotation text
-    const nodeData = JSON.parse(this.node.getPluginData(DATA_KEYS.keystopNodeData) || null);
+    const nodeDataType = nodeType === 'keystop' ? DATA_KEYS.keystopNodeData : DATA_KEYS.labelNodeData;
+    const nodeData = JSON.parse(this.node.getPluginData(nodeDataType) || null);
 
     if (!nodeData || (nodeData && !nodeData.annotationText)) {
       result.status = 'error';
@@ -2208,8 +2209,10 @@ export default class Painter {
 
     // set up some information
     const { annotationText } = nodeData;
+    // const annotationType: 'keystop' | 'label' = nodeType; // tktk
     const annotationType: 'keystop' = 'keystop';
-    const annotationName = `Keystop for ${this.node.name}`;
+    const typeCapitalized = annotationType.charAt(0).toUpperCase() + annotationType.slice;
+    const annotationName = `${typeCapitalized} for ${this.node.name}`;
 
     // construct the base annotation elements
     const annotationBundle = buildAnnotation({
@@ -2218,6 +2221,7 @@ export default class Painter {
       type: annotationType,
     });
 
+    // set individual key annotations for keystops
     const auxAnnotations: Array<FrameNode> = [];
     if (nodeData.keys && nodeData.keys.length > 0) {
       nodeData.keys.forEach((keyEntry) => {
@@ -2281,7 +2285,7 @@ export default class Painter {
       node: annotationNode,
       frame: this.frame,
       page: this.page,
-      type: 'keystop',
+      type: annotationType,
     });
 
     // ---------- set node tracking data
@@ -2334,185 +2338,6 @@ export default class Painter {
     };
     annotationNode.setPluginData(
       DATA_KEYS.keystopLinkId,
-      JSON.stringify(annotatedLinkData),
-    );
-
-    // return a successful result
-    result.status = 'success';
-    return result;
-  }
-
-  /** WIP
-   * @description Builds a Keystop Annotation in Figma. Expects keystop node data to be
-   * available (`annotationText` and potential `keys` for auxilary annotations).
-   *
-   * @kind function
-   * @name addKeystop
-   *
-   * @returns {Object} A result object container success/error status and log/toast messages.
-   */
-  addLabel() {
-    const result: {
-      status: 'error' | 'success',
-      messages: {
-        toast: string,
-        log: string,
-      },
-    } = {
-      status: null,
-      messages: {
-        toast: null,
-        log: null,
-      },
-    };
-
-    result.messages.log = `Draw the keyboard stop annotation for “${this.node.name}”`;
-
-    // retrieve the node data with our annotation text
-    const nodeData = JSON.parse(this.node.getPluginData(DATA_KEYS.labelNodeData) || null);
-
-    if (!nodeData || (nodeData && !nodeData.annotationText)) {
-      result.status = 'error';
-      result.messages.log = 'Node missing annotationText';
-      return result;
-    }
-
-    // return an error if the selection is not placed in a frame
-    if (!this.frame || (this.frame.id === this.node.id)) {
-      result.status = 'error';
-      result.messages.log = 'Selection not on frame';
-      result.messages.toast = 'Your selection needs to be in an outer frame';
-      return result;
-    }
-
-    // set up some information
-    const { annotationText } = nodeData;
-    const annotationType: 'keystop' = 'keystop';
-    const annotationName = `Keystop for ${this.node.name}`;
-
-    // construct the base annotation elements
-    const annotationBundle = buildAnnotation({
-      mainText: annotationText,
-      secondaryText: null,
-      type: annotationType,
-    });
-
-    // const auxAnnotations: Array<FrameNode> = [];
-    // if (nodeData.keys && nodeData.keys.length > 0) {
-    //   nodeData.keys.forEach((keyEntry) => {
-    //     const auxAnnotation: FrameNode = buildAuxAnnotation(keyEntry);
-    //     auxAnnotation.layoutAlign = 'INHERIT';
-    //     auxAnnotations.push(auxAnnotation);
-    //   });
-    // }
-
-    // grab the position from crawler
-    const crawler = new Crawler({ for: [this.node] });
-    const positionResult = crawler.position();
-    const relativePosition = positionResult.payload;
-
-    // group and position the base annotation elements
-    const nodePosition: PluginNodePosition = {
-      frameWidth: this.frame.width,
-      frameHeight: this.frame.height,
-      width: relativePosition.width,
-      height: relativePosition.height,
-      x: relativePosition.x,
-      y: relativePosition.y,
-    };
-
-    const baseAnnotationNode = positionAnnotation(
-      this.frame,
-      annotationName,
-      annotationBundle,
-      nodePosition,
-      'keystop',
-    );
-
-    // const initialX = baseAnnotationNode.x;
-    // const initialY = baseAnnotationNode.y;
-
-    const annotationNode: FrameNode = baseAnnotationNode;
-    // if (auxAnnotations.length > 0) {
-    //   annotationNode = figma.createFrame();
-    //   annotationNode.clipsContent = false;
-    //   annotationNode.layoutMode = 'HORIZONTAL';
-    //   annotationNode.counterAxisSizingMode = 'AUTO';
-    //   annotationNode.layoutAlign = 'INHERIT';
-    //   annotationNode.itemSpacing = 4;
-    //   annotationNode.fills = [];
-    //   annotationNode.name = `${baseAnnotationNode.name} (with Keys)`;
-
-    //   // add the base annotation
-    //   annotationNode.appendChild(baseAnnotationNode);
-
-    //   // add the key annotations
-    //   auxAnnotations.forEach(auxAnnotation => annotationNode.appendChild(auxAnnotation));
-
-    //   baseAnnotationNode.layoutAlign = 'INHERIT';
-    //   annotationNode.resize(baseAnnotationNode.width, baseAnnotationNode.height);
-    //   annotationNode.x = initialX;
-    //   annotationNode.y = initialY;
-    // }
-
-    // set it in the correct containers
-    setNodeInContainers({
-      node: annotationNode,
-      frame: this.frame,
-      page: this.page,
-      type: 'keystop',
-    });
-
-    // ---------- set node tracking data
-    const linkId: string = uuid();
-    const newAnnotatedNodeData: PluginNodeTrackingData = {
-      annotationId: annotationNode.id,
-      id: this.node.id,
-      linkId,
-      topFrameId: this.frame.id,
-      nodePosition,
-    };
-
-    // update the `trackingSettings` array
-    const trackingDataRaw = JSON.parse(
-      this.page.getPluginData(DATA_KEYS.labelAnnotations) || null,
-    );
-    let trackingData: Array<PluginNodeTrackingData> = [];
-    if (trackingDataRaw) {
-      trackingData = trackingDataRaw;
-    }
-
-    // set the node data in the `trackingData` array
-    trackingData = updateArray(
-      trackingData,
-      newAnnotatedNodeData,
-      'id',
-      'update',
-    );
-
-    // commit the `trackingData` update
-    this.page.setPluginData(
-      DATA_KEYS.labelAnnotations,
-      JSON.stringify(trackingData),
-    );
-
-    // set the `linkId` on the annotated node
-    const nodeLinkData: PluginNodeLinkData = {
-      id: linkId,
-      role: 'node',
-    };
-    this.node.setPluginData(
-      DATA_KEYS.labelLinkId,
-      JSON.stringify(nodeLinkData),
-    );
-
-    // set the `linkId` on the annotation node
-    const annotatedLinkData: PluginNodeLinkData = {
-      id: linkId,
-      role: 'annotation',
-    };
-    annotationNode.setPluginData(
-      DATA_KEYS.labelLinkId,
       JSON.stringify(annotatedLinkData),
     );
 

--- a/src/Painter.ts
+++ b/src/Painter.ts
@@ -2163,9 +2163,10 @@ export default class Painter {
     return result;
   }
 
-  /** WIP
-   * @description Builds a Keystop Annotation in Figma. Expects keystop node data to be
-   * available (`annotationText` and potential `keys` for auxilary annotations).
+  /**
+   * @description Builds a Keystop or Label Annotation in Figma. Expects appropriate node data to
+   * be available (`annotationText`, `labels`, and potential `keys` for auxilary annotations).
+   * Note: the `labels` and Label annotation portions are WIP.
    *
    * @kind function
    * @name addStop
@@ -2236,7 +2237,8 @@ export default class Painter {
     const positionResult = crawler.position();
     const relativePosition = positionResult.payload;
 
-    // group and position the base annotation elements
+    // ---------- group and position the base annotation elements
+    // set up `nodePosition` based on `frame` and `relativePosition` from `Crawler`
     const nodePosition: PluginNodePosition = {
       frameWidth: this.frame.width,
       frameHeight: this.frame.height,
@@ -2246,6 +2248,7 @@ export default class Painter {
       y: relativePosition.y,
     };
 
+    // position the base annotation on the artboard
     const baseAnnotationNode = positionAnnotation(
       this.frame,
       annotationName,
@@ -2253,10 +2256,10 @@ export default class Painter {
       nodePosition,
       'keystop',
     );
-
     const initialX = baseAnnotationNode.x;
     const initialY = baseAnnotationNode.y;
 
+    // if applicable, add auxilary annotations (currently `keys`)
     let annotationNode: FrameNode = baseAnnotationNode;
     if (auxAnnotations.length > 0) {
       annotationNode = figma.createFrame();
@@ -2280,7 +2283,7 @@ export default class Painter {
       annotationNode.y = initialY;
     }
 
-    // set it in the correct containers
+    // set the annotation frame(s) into the correct container group layers in Figma
     setNodeInContainers({
       node: annotationNode,
       frame: this.frame,
@@ -2289,6 +2292,8 @@ export default class Painter {
     });
 
     // ---------- set node tracking data
+    // node tracking data is used for diffing changes to the source nodes and re-drawing or
+    // removing annotations as necessary
     const linkId: string = uuid();
     const newAnnotatedNodeData: PluginNodeTrackingData = {
       annotationId: annotationNode.id,


### PR DESCRIPTION
* Adapts `addKeystop` in the `Painter` class into `addStop` for use with Labels.
* In `App`, separates out the node tracking/diffing from `refreshGUI` into `diffChanges` and enables it for Keyboard and Labels simultaneously.