### PR TITLE
Labels: Annotations position updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6611,11 +6611,6 @@
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
-    "number-converter-alphabet": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/number-converter-alphabet/-/number-converter-alphabet-1.1.0.tgz",
-      "integrity": "sha1-+pReZ3WAYtg2P/gEiOLTDCKv07g="
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   },
   "dependencies": {
     "hex-rgb": "^4.1.0",
-    "number-converter-alphabet": "^1.1.0",
     "svelte": "^3.24.1",
     "uuid-random": "^1.3.2"
   },

--- a/src/App.ts
+++ b/src/App.ts
@@ -7,6 +7,7 @@ import {
   existsInArray,
   findTopFrame,
   getPeerPluginData,
+  lettersToNumbers,
   numberToLetters,
   resizeGUI,
   updateArray,
@@ -1894,7 +1895,7 @@ export default class App {
           role,
         } = getStopData(nodeType, node);
 
-        let displayPosition: string = position.toString();
+        let displayPosition: string = position ? position.toString() : '';
         if (currentView === 'a11y-labels') {
           // convert numeric position to alpha for view
           displayPosition = numberToLetters(position);
@@ -2287,6 +2288,9 @@ export default class App {
 
     // force the new position into a positive integer
     let newPosition: number = parseInt(options.position, 10);
+    if (newPosition.toString() === 'NaN') {
+      newPosition = lettersToNumbers(options.position);
+    }
 
     if (!nodeId || !newPosition) {
       messenger.log(`Cannot update ${nodeType}; missing node ID or new position`, 'error');

--- a/src/App.ts
+++ b/src/App.ts
@@ -7,12 +7,11 @@ import {
   existsInArray,
   findTopFrame,
   getPeerPluginData,
+  numberToLetters,
   resizeGUI,
   updateArray,
 } from './Tools';
 import { DATA_KEYS, GUI_SETTINGS } from './constants';
-
-const alphaNumConvert = require('number-converter-alphabet');
 
 /**
  * @description A shared helper function to set up in-UI messages and the logger.
@@ -1895,12 +1894,10 @@ export default class App {
           role,
         } = getStopData(nodeType, node);
 
-        let displayPosition = position;
+        let displayPosition: string = position.toString();
         if (currentView === 'a11y-labels') {
           // convert numeric position to alpha for view
-          const { ALPHABET_ASCII } = alphaNumConvert;
-          const convert = alphaNumConvert.default;
-          displayPosition = convert((position - 1), ALPHABET_ASCII, { implicitLeadingZero: true });
+          displayPosition = numberToLetters(position);
         }
         const viewObject: PluginViewObject = {
           hasStop,

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -539,9 +539,9 @@ const matchMasterPeerNode = (node: any, topNode: InstanceNode) => {
  *
  * @returns {string} The letter version of that number.
  */
-const numberToLetters = (num) => {
-  let number = num;
-  let letters = '';
+const numberToLetters = (num: number): string => {
+  let number: number = num;
+  let letters: string = '';
   let counter;
 
   while (number > 0) {

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -531,6 +531,28 @@ const matchMasterPeerNode = (node: any, topNode: InstanceNode) => {
 };
 
 /**
+ * @description Takes a number and converts it to a letter(s) representation for labels.
+ *
+ * @kind function
+ * @name toSentenceCase
+ * @param {number} num The order number of the annotation.
+ *
+ * @returns {string} The letter version of that number.
+ */
+const numberToLetters = (num) => {
+  let number = num;
+  let letters = '';
+  let counter;
+
+  while (number > 0) {
+    counter = (number - 1) % 26;
+    letters = String.fromCharCode(65 + counter) + letters;
+    number = Math.floor((number - counter) / 26);
+  }
+  return letters || undefined;
+};
+
+/**
  * @description Takes a Figma page object and a `nodeId` and uses the Figma API’s
  * `getPluginData` to extract and return a specific node’s settings.
  *
@@ -891,28 +913,6 @@ const toSentenceCase = (anyString: string): string => {
   return titleCaseString;
 };
 
-/**
- * @description Takes a number and converts it to a letter(s) representation for labels.
- *
- * @kind function
- * @name toSentenceCase
- * @param {number} num The order number of the annotation.
- *
- * @returns {string} The letter version of that number.
- */
-const numberToLetters = (num) => {
-  let number = num;
-  let letters = '';
-  let counter;
-
-  while (number > 0) {
-    counter = (number - 1) % 26;
-    letters = String.fromCharCode(65 + counter) + letters;
-    number = Math.floor((number - counter) / 26);
-  }
-  return letters || undefined;
-};
-
 export {
   asyncForEach,
   awaitUIReadiness,
@@ -932,10 +932,10 @@ export {
   isVisible,
   loadFirstAvailableFontAsync,
   matchMasterPeerNode,
+  numberToLetters,
   resizeGUI,
   setNodeSettings,
   toSentenceCase,
   updateArray,
   updateNestedArray,
-  numberToLetters,
 };

--- a/src/Tools.ts
+++ b/src/Tools.ts
@@ -531,10 +531,10 @@ const matchMasterPeerNode = (node: any, topNode: InstanceNode) => {
 };
 
 /**
- * @description Takes a number and converts it to a letter(s) representation for labels.
+ * @description Takes a number and converts it to a letterset representation (A, AA, BA, etc.).
  *
  * @kind function
- * @name toSentenceCase
+ * @name numberToLetters
  * @param {number} num The order number of the annotation.
  *
  * @returns {string} The letter version of that number.
@@ -799,6 +799,33 @@ const isVisible = (node: SceneNode): boolean => {
 };
 
 /**
+ * @description Takes a letterset (A, AA, BA) and converts it to an integer.
+ *
+ * @kind function
+ * @name lettersToNumbers
+ * @param {string} num The string of letters representing a number.
+ *
+ * @returns {number} The integer based on the letterset.
+ */
+const lettersToNumbers = (letterset: string): number => {
+  let totalNumber: number = 0;
+  const lettersArray: Array<string> = letterset.toUpperCase().split('');
+  const numbersArray: Array<number> = [];
+
+  // iterate through each letter and convert to a number
+  lettersArray.forEach((letter) => {
+    const number: number = (letter.charCodeAt(0) - 64);
+    numbersArray.push(number);
+  });
+
+  // iterate the numbers and calculate the position
+  numbersArray.forEach((number) => {
+    totalNumber = (totalNumber * 26 + number);
+  });
+  return totalNumber;
+};
+
+/**
  * @description Takes an array of typefaces (`FontName`), iterates through the array, checking
  * the system available of each typeface and loading the first available.
  *
@@ -930,6 +957,7 @@ export {
   hexToDecimalRgb,
   isInternal,
   isVisible,
+  lettersToNumbers,
   loadFirstAvailableFontAsync,
   matchMasterPeerNode,
   numberToLetters,

--- a/src/code.ts
+++ b/src/code.ts
@@ -84,7 +84,8 @@ const dispatcher = async (action: {
         }
         break;
       }
-      case 'a11y-keyboard-update-stop': {
+      case 'a11y-keyboard-update-stop':
+      case 'a11y-labels-update-stop': {
         const { id } = payload;
         const nodeType: 'keystop' | 'label' = actionType === 'a11y-keyboard-update-stop' ? 'keystop' : 'label';
         if (id) {

--- a/src/views/ItemHeader.svelte
+++ b/src/views/ItemHeader.svelte
@@ -57,7 +57,17 @@
   };
 
   const updatePosition = (newPosition) => {
-    if (parseInt(originalPosition, 10) !== parseInt(newPosition, 10)) {
+    // only update if the positions are different
+    let sendPositionUpdate = false;
+    if (type === 'keystop') {
+      if (parseInt(originalPosition, 10) !== parseInt(newPosition, 10)) {
+        sendPositionUpdate = true;
+      }
+    } else if (originalPosition !== newPosition) {
+      sendPositionUpdate = true;
+    }
+
+    if (sendPositionUpdate) {
       parent.postMessage({
         pluginMessage: {
           action: `${type}-update-stop`,

--- a/src/views/ItemHeader.svelte
+++ b/src/views/ItemHeader.svelte
@@ -75,7 +75,11 @@
 
   beforeUpdate(() => {
     // check `position` against original to see if it was updated on the Figma side
-    if (parseInt(originalPosition, 10) !== parseInt(position, 10)) {
+    if (type === 'keystop') {
+      if (parseInt(originalPosition, 10) !== parseInt(position, 10)) {
+        resetValue = true;
+      }
+    } else if (originalPosition !== position) {
       resetValue = true;
     }
 


### PR DESCRIPTION
Finishes the full loop on Labels: allows position to be updated by either integer or letterset string convention (i.e. “AA”, “AF”).

_Note:_ I wrote a `lettersToNumber` complement to the `numberToLetters` helper and also removed the “number-converter-alphabet” convention.