### PR TITLE
info panel - update slack channel name

### DIFF
--- a/src/views/InfoPanel.svelte
+++ b/src/views/InfoPanel.svelte
@@ -28,7 +28,7 @@
       <p>Built by the Design Tools Team</p>
       <p>
         Join us in Slack: <br />
-        #ued-tool-specter
+        #design-tools-plugins
       </p>
     {:else}
       <p>


### PR DESCRIPTION
Updates the Info Panel slack channel name to `#design-tools-plugins`